### PR TITLE
Added support to query unmineable for worker stats.

### DIFF
--- a/src/main/modules/UnmineableModule.ts
+++ b/src/main/modules/UnmineableModule.ts
@@ -3,9 +3,16 @@ import axios from 'axios';
 import SharedModule from './SharedModule';
 
 const TICKER_URL = 'https://api.unmineable.com/v4/address';
+const WORKERS_URL = 'https://api.unminable.com/v4/account';
 
 async function getCoin(_event: IpcMainInvokeEvent, coin: string, address: string) {
   const url = `${TICKER_URL}/${address}?coin=${coin}`;
+
+  return axios.get(url).then((r) => JSON.stringify(r.data));
+}
+
+async function getWorkers(_event: IpcMainInvokeEvent, uuid: string) {
+  const url = `${WORKERS_URL}/${uuid}/workers`;
 
   return axios.get(url).then((r) => JSON.stringify(r.data));
 }
@@ -15,6 +22,7 @@ export default class UnmineableModule implements SharedModule {
 
   handlers = {
     'ipc-getUnmineableCoin': getCoin,
+    'ipc-getUnmineableWorkers': getWorkers,
   };
 
   reset = () => {};

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -34,6 +34,9 @@ contextBridge.exposeInMainWorld('unmineable', {
   getCoin(coin, address) {
     return ipcRenderer.invoke('ipc-getUnmineableCoin', coin, address);
   },
+  getWorkers(uuid) {
+    return ipcRenderer.invoke('ipc-getUnmineableWorkers', uuid);
+  },
 });
 
 contextBridge.exposeInMainWorld('ticker', {

--- a/src/renderer/MinerContext.ts
+++ b/src/renderer/MinerContext.ts
@@ -3,6 +3,6 @@ import { MinerState } from './services/MinerManager';
 
 export const MinerContext = React.createContext<MinerState>({
   state: 'inactive',
-  currentCoin: '',
-  miner: '',
+  currentCoin: null,
+  miner: null,
 });

--- a/src/renderer/screens/HomeScreen.tsx
+++ b/src/renderer/screens/HomeScreen.tsx
@@ -3,7 +3,7 @@ import { Container, Divider, Typography, Button } from '@mui/material';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import { startMiner, stopMiner, nextCoin, serviceState$ } from '../services/MinerManager';
 import { ticker, updateTicker } from '../services/CoinFeed';
-import { unmineable$, updateCoins } from '../services/UnmineableFeed';
+import { unmineableCoins$, unmineableWorkers$, updateCoins, updateWorkers } from '../services/UnmineableFeed';
 import { MinerContext } from '../MinerContext';
 
 export function HomeScreen(): JSX.Element {
@@ -26,17 +26,27 @@ export function HomeScreen(): JSX.Element {
       });
     });
 
-    const unmineableSubscription = unmineable$.subscribe((coins) => {
+    const unmineableCoinsSubscription = unmineableCoins$.subscribe((coins) => {
       coins.forEach((c) => {
+        if (c.symbol === minerContext.currentCoin) {
+          updateWorkers(c.uuid);
+        }
+
         // eslint-disable-next-line no-console
         console.log(`Symbol: ${c.symbol}, Balance: ${c.balance}, Threshold: ${c.threshold}`);
       });
     });
 
+    const unmineableWorkersSubscription = unmineableWorkers$.subscribe((stats) => {
+      // eslint-disable-next-line no-console
+      console.log(`Stats: ${JSON.stringify(stats)}`);
+    });
+
     return () => {
       minerSubscription.unsubscribe();
       tickerSubscription.unsubscribe();
-      unmineableSubscription.unsubscribe();
+      unmineableCoinsSubscription.unsubscribe();
+      unmineableWorkersSubscription.unsubscribe();
     };
   });
 

--- a/src/shared/UnmineableApi.ts
+++ b/src/shared/UnmineableApi.ts
@@ -1,7 +1,9 @@
 export interface UnmineableApi {
   getCoin: (coins: string, address: string) => Promise<string>;
+  getWorkers: (uuid: string) => Promise<string>;
 }
 
 export const unmineableApi = window.unmineable ?? {
   getCoin: () => Promise.resolve(''),
+  getWorkers: () => Promise.resolve(''),
 };


### PR DESCRIPTION
Added back-end API calls to get worker statistics from unmineable.  This includes time series data used to generate graphs (up to 4, one for each algorithm).  Also updated subscriptions to differentiate between coin updates and worker updated.  The `HomeScreen` can now subscribe to these events but currently only dumps them to the console.

Currently we only look for worker information for the coin currently being mined.  This is because a) The user probably won't be mining anything else and b) unmineable is very opaque about their rate limits so we need to minimize calls whenever possible.