### PR TITLE
Fixed binding error for wallets when editing a coin.

### DIFF
--- a/src/renderer/dialogs/EditCoinDialog.tsx
+++ b/src/renderer/dialogs/EditCoinDialog.tsx
@@ -66,7 +66,13 @@ export function EditCoinDialog(props: EditCoinDialogProps) {
               </div>
               <Divider />
               <FormControlLabel label="Enabled" control={<Switch name="enabled" checked={watch('enabled')} inputRef={register('enabled').ref} onChange={register('enabled').onChange} />} />
-              <TextField label={walletLabel()} select disabled={shouldDisableWalletSelection()} {...register('wallet')} value={watch('wallet') ?? null}>
+              <TextField
+                label={walletLabel()}
+                select
+                disabled={shouldDisableWalletSelection()}
+                {...register('wallet')}
+                value={watch('wallet') ?? compatibleWallets.length ? compatibleWallets[0].name : ''}
+              >
                 {compatibleWallets
                   .sort((a, b) => a.name.localeCompare(b.name))
                   .map((w) => (


### PR DESCRIPTION
Fixed a bug that was causing binding errors in the `EditCoin` dialog.  This was occurring when attempting to edit a coin that had compatible wallets, but none were selected.  Changed the default `value` logic to check the config first, look at compatible wallets second, and default to `''` if no compatible wallet found.