### PR TITLE
Wired up 'Browse' button.

### DIFF
--- a/src/renderer/dialogs/EditMinerDialog.tsx
+++ b/src/renderer/dialogs/EditMinerDialog.tsx
@@ -97,7 +97,6 @@ export function EditMinerDialog(props: EditMinerDialogProps) {
               <Stack direction="row">
                 <TextField
                   required
-                  disabled
                   label="Installation Path"
                   value={watch('installationPath') ?? ''}
                   {...register('installationPath', {


### PR DESCRIPTION
Added wireup for browse button.  The back-end code was written a while back but never hooked up to the front-end.  Also disabled the textbox itself so that input has to be made through the dialog.

@evan-cohen what are your thoughts on this?  I can go either way.  Disabling manual entry may make the app "harder" to use, but it also cuts down on the possibility that the user can enter garbage data in the system.