### PR TITLE
Added pause button to stop auto-scrolling the monitor output.

### DIFF
--- a/src/renderer/components/AutoScrollTextArea.tsx
+++ b/src/renderer/components/AutoScrollTextArea.tsx
@@ -7,20 +7,17 @@ type AutoScrollTextAreaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 };
 
 export function AutoScrollTextArea(props: AutoScrollTextAreaProps) {
-  const { value, isPaused } = props;
+  const { isPaused, ...domProps } = props;
   const theme = useTheme();
   const textRef = useRef<HTMLTextAreaElement>(null);
 
-  const domProps = { ...props };
-  delete domProps.isPaused;
-
   useLayoutEffect(() => {
-    if (!isPaused) {
-      if (textRef.current !== null) {
-        textRef.current.scrollTop = textRef.current.scrollHeight;
-      }
+    if (!isPaused && textRef.current !== null) {
+      textRef.current.scrollTop = textRef.current.scrollHeight;
     }
-  }, [isPaused, value]);
+
+    // eslint-disable-next-line react/destructuring-assignment
+  }, [isPaused, props.value]);
 
   // eslint-disable-next-line react/jsx-props-no-spreading
   return <textarea {...domProps} ref={textRef} style={{ backgroundColor: theme.palette.background.paper, color: theme.palette.text.secondary, height: 'calc(100vh - 10rem)' }} />;

--- a/src/renderer/screens/MonitorScreen.tsx
+++ b/src/renderer/screens/MonitorScreen.tsx
@@ -34,7 +34,6 @@ export function MonitorScreen(): JSX.Element {
       <Divider />
       <Button onClick={() => setIsPaused(!isPaused)}>{isPaused ? <PlayArrowIcon /> : <PauseIcon />}</Button>
       <Button onClick={clearLog}>Clear Log</Button>
-      <Button />
       <Box
         sx={{
           '& .MuiDataGrid-cell--editing': {


### PR DESCRIPTION
Created an addition icon button for pausing console output.

@evan-cohen this *works*, but is it a good strategy to be deleting items from the props like this?  It's needed because passing `isPaused` to `<textarea />` creates an error in the logs.