### PR TITLE
refactor(about): use interactive buttons for links

### DIFF
--- a/src/renderer/screens/AboutScreen.tsx
+++ b/src/renderer/screens/AboutScreen.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useState } from 'react';
-import { Container, Typography, Divider, Button } from '@mui/material';
-import { ScreenHeader } from '../components';
-import { aboutApi } from '../../shared/AboutApi';
 import { GitHub } from '@mui/icons-material';
+import { Button, Container, Divider, Typography } from '@mui/material';
 import { Box } from '@mui/system';
+import { useEffect, useState } from 'react';
+import { aboutApi } from '../../shared/AboutApi';
+import { ScreenHeader } from '../components';
 
 function ExternalLink(props: { label: string; text: string; url: string }) {
   const { label, text, url } = props;


### PR DESCRIPTION
- Replace clickable `Typography` components with `Button`s so that its more evident that they're interactive elements
- Move the GitHub project page link as an icon button below the version information
- Replace semantic line breaks `<br />` with margins
- Nest the miner website links under a "Miners" header

Closes #128 

<img width="910" alt="image" src="https://user-images.githubusercontent.com/25253818/160217207-bbca712e-d30b-4c73-974b-16d864843b01.png">
