### PR TITLE
Default miner is now loaded from app settings.

### DIFF
--- a/src/__tests__/services/AppSettingsService.tests.ts
+++ b/src/__tests__/services/AppSettingsService.tests.ts
@@ -78,6 +78,7 @@ describe('App Settings Service', () => {
       const appSettings: AppSettings = {
         settings: {
           workerName: 'worker',
+          defaultMiner: '',
           proxy: '',
         },
         pools: {

--- a/src/models/AppSettings.ts
+++ b/src/models/AppSettings.ts
@@ -1,5 +1,6 @@
 export type GeneralSettings = {
   workerName: string;
+  defaultMiner: string;
   proxy: string;
 };
 

--- a/src/models/DefaultSettings.ts
+++ b/src/models/DefaultSettings.ts
@@ -13,6 +13,7 @@ export const DefaultSettings = {
   settings: {
     settings: {
       workerName: 'default',
+      defaultMiner: 'default',
       proxy: '',
     },
     pools: {

--- a/src/renderer/services/MinerManager.ts
+++ b/src/renderer/services/MinerManager.ts
@@ -4,7 +4,7 @@ import * as miningService from './MinerService';
 import * as config from './AppSettingsService';
 import { minerApi } from '../../shared/MinerApi';
 import { ALL_COINS, CoinDefinition, AVAILABLE_MINERS, Miner, Coin, MinerInfo, Wallet, MinerState, minerState$, minerErrors$ } from '../../models';
-import { getMiners } from './AppSettingsService';
+import { getMiners, getAppSettings } from './AppSettingsService';
 import { downloadMiner } from './DownloadManager';
 
 type CoinSelection = {
@@ -148,8 +148,11 @@ async function getMinerState() {
 }
 
 async function getDefaultMiner() {
+  const appSettings = await getAppSettings();
   const miners = await getMiners();
-  return miners.length > 0 ? miners[0] : undefined;
+  const miner = miners.find((m) => m.name === appSettings.settings.defaultMiner);
+
+  return miner !== undefined ? miner : undefined;
 }
 
 async function setInitialState() {


### PR DESCRIPTION
Updated the logic in `MinerManager` to read the default miner from the configuration rather than grab the first enabled miner from the loaded settings.