### PR TITLE
Updated installer to automatically launch the application as admin.

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,9 +41,8 @@
     ],
     "afterSign": ".erb/scripts/notarize.js",
     "win": {
-      "target": [
-        "nsis"
-      ]
+      "target": ["nsis"],
+      "requestedExecutionLevel": "requireAdministrator"
     },
     "directories": {
       "app": "release/app",


### PR DESCRIPTION
Added an additional flag to the installer configuration to tell the installer that when the application is launched that it needs to be run as an administrator.  This is necessary because OC settings cannot be set without elevated privileges.