### PR TITLE
Default miner selection

### DIFF
--- a/src/renderer/components/Toolbar.tsx
+++ b/src/renderer/components/Toolbar.tsx
@@ -36,7 +36,10 @@ export function Toolbar({ drawerWidth }: { drawerWidth: number }) {
   const [miners, setLoadedMiners] = useState(Array<Miner>());
 
   useEffect(() => {
-    getMiners().then(setLoadedMiners);
+    getMiners()
+      .then(setLoadedMiners)
+      // eslint-disable-next-line no-console
+      .catch((err) => console.error('Failed to load miners: ', err));
   }, []);
 
   const setDefaultMiner = async (name: string) => {


### PR DESCRIPTION
Builds upon #207 to add selection of the default miner to the global bottom toolbar:
<img width="1032" alt="image" src="https://user-images.githubusercontent.com/25253818/161433857-168401f5-7b40-40f3-91c3-c485a49d5833.png">

Closes #33
