### PR TITLE
Fixed parameter being sent in for the worker name.

### DIFF
--- a/src/renderer/services/MinerManager.ts
+++ b/src/renderer/services/MinerManager.ts
@@ -102,7 +102,7 @@ async function changeCoin() {
       const appSettings = await config.getAppSettings();
       const { miner, minerInfo, coin, coinInfo, wallet } = selection;
 
-      const cs = getConnectionString(coin.symbol, wallet.address, wallet.memo, miner.name, getRandom(coinInfo.referrals));
+      const cs = getConnectionString(coin.symbol, wallet.address, wallet.memo, appSettings.settings.workerName, getRandom(coinInfo.referrals));
       const filePath = path.join(miner.version, minerInfo.exe);
       const minerArgs = minerInfo.getArgs(miner.algorithm, cs, appSettings.pools[miner.algorithm]);
       const extraArgs = miner.parameters;


### PR DESCRIPTION
When starting the miner, the wrong parameter was being sent in for the worker name.  Instead of using the setting from `AppSettings` it was passing in the name of the miner profile.

To fix I just swapped parameters.  This problem was probably around for a long time but never noticed because the default miner and worker share the same name 'default'.  Once IC created a miner profile with a different name the issue became apparent.