### PR TITLE
Add configurable coin selection strategy

### DIFF
--- a/src/__tests__/services/AppSettingsService.tests.ts
+++ b/src/__tests__/services/AppSettingsService.tests.ts
@@ -79,6 +79,7 @@ describe('App Settings Service', () => {
         settings: {
           workerName: 'worker',
           defaultMiner: '',
+          coinStrategy: 'normal',
           proxy: '',
         },
         pools: {

--- a/src/__tests__/services/strategies/normal.tests.ts
+++ b/src/__tests__/services/strategies/normal.tests.ts
@@ -1,0 +1,97 @@
+import { Coin } from '../../../models';
+import * as config from '../../../renderer/services/AppSettingsService';
+import { selectCoin } from '../../../renderer/services/strategies/Normal';
+
+describe('Normal Coin Selection', () => {
+  it('Should return first coin if no current coin given', async () => {
+    // Arrange.
+    const coins: Coin[] = [
+      {
+        symbol: 'ETH',
+        wallet: null,
+        enabled: true,
+        duration: 1,
+      },
+    ];
+
+    jest.spyOn(config, 'getCoins').mockReturnValue(Promise.resolve(coins));
+
+    // Act.
+    const result = await selectCoin(null);
+
+    // Assert.
+    expect(result.symbol).toBe('ETH');
+  });
+
+  it('Should return first coin if unknown coin given', async () => {
+    // Arrange.
+    const coins: Coin[] = [
+      {
+        symbol: 'ETH',
+        wallet: null,
+        enabled: true,
+        duration: 1,
+      },
+    ];
+
+    jest.spyOn(config, 'getCoins').mockReturnValue(Promise.resolve(coins));
+
+    // Act.
+    const result = await selectCoin('unknown');
+
+    // Assert.
+    expect(result.symbol).toBe('ETH');
+  });
+
+  it('Should return first coin if the last coin was given', async () => {
+    // Arrange.
+    const coins: Coin[] = [
+      {
+        symbol: 'ETH',
+        wallet: null,
+        enabled: true,
+        duration: 1,
+      },
+      {
+        symbol: 'TRX',
+        wallet: null,
+        enabled: true,
+        duration: 1,
+      },
+    ];
+
+    jest.spyOn(config, 'getCoins').mockReturnValue(Promise.resolve(coins));
+
+    // Act.
+    const result = await selectCoin('TRX');
+
+    // Assert.
+    expect(result.symbol).toBe('ETH');
+  });
+
+  it('Should return next coin in the list', async () => {
+    // Arrange.
+    const coins: Coin[] = [
+      {
+        symbol: 'ETH',
+        wallet: null,
+        enabled: true,
+        duration: 1,
+      },
+      {
+        symbol: 'TRX',
+        wallet: null,
+        enabled: true,
+        duration: 1,
+      },
+    ];
+
+    jest.spyOn(config, 'getCoins').mockReturnValue(Promise.resolve(coins));
+
+    // Act.
+    const result = await selectCoin('ETH');
+
+    // Assert.
+    expect(result.symbol).toBe('TRX');
+  });
+});

--- a/src/__tests__/services/strategies/normal.tests.ts
+++ b/src/__tests__/services/strategies/normal.tests.ts
@@ -1,5 +1,4 @@
 import { Coin } from '../../../models';
-import * as config from '../../../renderer/services/AppSettingsService';
 import { selectCoin } from '../../../renderer/services/strategies/Normal';
 
 describe('Normal Coin Selection', () => {
@@ -14,10 +13,8 @@ describe('Normal Coin Selection', () => {
       },
     ];
 
-    jest.spyOn(config, 'getCoins').mockReturnValue(Promise.resolve(coins));
-
     // Act.
-    const result = await selectCoin(null);
+    const result = selectCoin(null, coins);
 
     // Assert.
     expect(result.symbol).toBe('ETH');
@@ -34,10 +31,8 @@ describe('Normal Coin Selection', () => {
       },
     ];
 
-    jest.spyOn(config, 'getCoins').mockReturnValue(Promise.resolve(coins));
-
     // Act.
-    const result = await selectCoin('unknown');
+    const result = selectCoin('unknown', coins);
 
     // Assert.
     expect(result.symbol).toBe('ETH');
@@ -60,10 +55,8 @@ describe('Normal Coin Selection', () => {
       },
     ];
 
-    jest.spyOn(config, 'getCoins').mockReturnValue(Promise.resolve(coins));
-
     // Act.
-    const result = await selectCoin('TRX');
+    const result = selectCoin('TRX', coins);
 
     // Assert.
     expect(result.symbol).toBe('ETH');
@@ -86,10 +79,8 @@ describe('Normal Coin Selection', () => {
       },
     ];
 
-    jest.spyOn(config, 'getCoins').mockReturnValue(Promise.resolve(coins));
-
     // Act.
-    const result = await selectCoin('ETH');
+    const result = selectCoin('ETH', coins);
 
     // Assert.
     expect(result.symbol).toBe('TRX');

--- a/src/__tests__/services/strategies/skynet.tests.ts
+++ b/src/__tests__/services/strategies/skynet.tests.ts
@@ -1,0 +1,53 @@
+import { Coin } from '../../../models';
+import * as config from '../../../renderer/services/AppSettingsService';
+import { selectCoin } from '../../../renderer/services/strategies/Skynet';
+
+describe('Skynet Coin Selection', () => {
+  it('Should return same coin if only one coin is enabled.', async () => {
+    // Arrange.
+    const coins: Coin[] = [
+      {
+        symbol: 'ETH',
+        wallet: null,
+        enabled: true,
+        duration: 1,
+      },
+    ];
+
+    jest.spyOn(config, 'getCoins').mockReturnValue(Promise.resolve(coins));
+
+    // Act.
+    const result = await selectCoin('ETH');
+
+    // Assert.
+    expect(result.symbol).toBe('ETH');
+  });
+
+  it('Should alternate coins if two or more coins is enabled.', async () => {
+    // Arrange.
+    const coins: Coin[] = [
+      {
+        symbol: 'ETH',
+        wallet: null,
+        enabled: true,
+        duration: 1,
+      },
+      {
+        symbol: 'TRX',
+        wallet: null,
+        enabled: true,
+        duration: 1,
+      },
+    ];
+
+    jest.spyOn(config, 'getCoins').mockReturnValue(Promise.resolve(coins));
+
+    // Act.
+    const result1 = await selectCoin('ETH');
+    const result2 = await selectCoin('TRX');
+
+    // Assert.
+    expect(result1.symbol).toBe('TRX');
+    expect(result2.symbol).toBe('ETH');
+  });
+});

--- a/src/__tests__/services/strategies/skynet.tests.ts
+++ b/src/__tests__/services/strategies/skynet.tests.ts
@@ -1,5 +1,4 @@
 import { Coin } from '../../../models';
-import * as config from '../../../renderer/services/AppSettingsService';
 import { selectCoin } from '../../../renderer/services/strategies/Skynet';
 
 describe('Skynet Coin Selection', () => {
@@ -14,10 +13,8 @@ describe('Skynet Coin Selection', () => {
       },
     ];
 
-    jest.spyOn(config, 'getCoins').mockReturnValue(Promise.resolve(coins));
-
     // Act.
-    const result = await selectCoin('ETH');
+    const result = selectCoin('ETH', coins);
 
     // Assert.
     expect(result.symbol).toBe('ETH');
@@ -40,11 +37,9 @@ describe('Skynet Coin Selection', () => {
       },
     ];
 
-    jest.spyOn(config, 'getCoins').mockReturnValue(Promise.resolve(coins));
-
     // Act.
-    const result1 = await selectCoin('ETH');
-    const result2 = await selectCoin('TRX');
+    const result1 = selectCoin('ETH', coins);
+    const result2 = selectCoin('TRX', coins);
 
     // Assert.
     expect(result1.symbol).toBe('TRX');

--- a/src/main/globals.ts
+++ b/src/main/globals.ts
@@ -17,6 +17,8 @@ export const globalStore = new Store<SettingsSchemaType>({
           type: 'object',
           properties: {
             workerName: { type: 'string' },
+            defaultMiner: { type: 'string' },
+            coinStrategy: { type: 'string' },
             proxy: { type: 'string' },
           },
           required: [],

--- a/src/models/AppSettings.ts
+++ b/src/models/AppSettings.ts
@@ -1,6 +1,9 @@
+import { CoinSelectionStrategy } from './Enums';
+
 export type GeneralSettings = {
   workerName: string;
   defaultMiner: string;
+  coinStrategy: CoinSelectionStrategy;
   proxy: string;
 };
 

--- a/src/models/CoinSelection.ts
+++ b/src/models/CoinSelection.ts
@@ -1,0 +1,13 @@
+import { Miner } from './Miner';
+import { MinerInfo } from './MinerInfo';
+import { Coin } from './Coin';
+import { CoinDefinition } from './CoinDefinition';
+import { Wallet } from './Wallet';
+
+export type CoinSelection = {
+  miner: Miner;
+  minerInfo: MinerInfo;
+  coin: Coin;
+  coinInfo: CoinDefinition;
+  wallet: Wallet;
+};

--- a/src/models/DefaultSettings.ts
+++ b/src/models/DefaultSettings.ts
@@ -24,6 +24,7 @@ export const DefaultSettings: SettingsSchemaType = {
     settings: {
       workerName: 'default',
       defaultMiner: 'nbminer',
+      coinStrategy: 'normal',
       proxy: '',
     },
     pools: {

--- a/src/models/Enums.ts
+++ b/src/models/Enums.ts
@@ -3,3 +3,4 @@ export const API_PORT = 60090;
 export type MinerName = 'phoenixminer' | 'lolminer' | 'nbminer' | 'trexminer' | 'xmrig';
 export type AlgorithmKind = 'CPU' | 'GPU';
 export type AlgorithmName = 'ethash' | 'etchash' | 'kawpow' | 'randomx';
+export type CoinSelectionStrategy = 'normal' | 'skynet';

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -3,7 +3,7 @@ export { CoinDefinition, ALL_COINS } from './CoinDefinition';
 export { CoinSelection } from './CoinSelection';
 export { Wallet } from './Wallet';
 export { Coin } from './Coin';
-export { AlgorithmName, AlgorithmKind, MinerName, API_PORT } from './Enums';
+export { AlgorithmName, AlgorithmKind, MinerName, CoinSelectionStrategy, API_PORT } from './Enums';
 export { AlgorithmInfo, AVAILABLE_ALGORITHMS } from './AlgorithmInfo';
 export { GeneralSettings, AppSettings } from './AppSettings';
 export { Miner } from './Miner';

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,5 +1,6 @@
 export { Chain, ALL_CHAINS } from './Chains';
 export { CoinDefinition, ALL_COINS } from './CoinDefinition';
+export { CoinSelection } from './CoinSelection';
 export { Wallet } from './Wallet';
 export { Coin } from './Coin';
 export { AlgorithmName, AlgorithmKind, MinerName, API_PORT } from './Enums';

--- a/src/renderer/screens/SettingsScreen.tsx
+++ b/src/renderer/screens/SettingsScreen.tsx
@@ -1,4 +1,4 @@
-import { Button, Container, Divider, FormControl, Stack, TextField, Typography } from '@mui/material';
+import { Button, Container, Divider, FormControl, Stack, TextField, Typography, MenuItem } from '@mui/material';
 import DownloadIcon from '@mui/icons-material/Download';
 import UploadIcon from '@mui/icons-material/Upload';
 import SaveIcon from '@mui/icons-material/Save';
@@ -24,6 +24,7 @@ export function SettingsScreen() {
     formState: { errors, isValid },
     handleSubmit,
     reset,
+    watch,
   } = useForm<AppSettings>({ defaultValues: DefaultSettings.settings });
 
   useEffect(() => {
@@ -78,6 +79,10 @@ export function SettingsScreen() {
     await loggingApi.openLogFolder();
   };
 
+  const pickCoinStrategy = (current: string) => {
+    return current === undefined ? 'normal' : current;
+  };
+
   const DefaultSpacing = 2;
 
   return (
@@ -115,6 +120,14 @@ export function SettingsScreen() {
               error={!!errors?.settings?.workerName}
               helperText={errors?.settings?.workerName?.message}
             />
+          </ConfigurableControl>
+        </Stack>
+        <Stack sx={{ width: '17.6rem', mt: 2 }}>
+          <ConfigurableControl description="How should the app pick the next coin to mine.">
+            <TextField label="Coin Strategy" select value={pickCoinStrategy(watch('settings.coinStrategy'))} {...register('settings.coinStrategy')}>
+              <MenuItem value="normal">Normal (next coin in the list)</MenuItem>
+              <MenuItem value="skynet">Skynet (let the app decide)</MenuItem>
+            </TextField>
           </ConfigurableControl>
         </Stack>
         <Stack sx={{ width: '25rem', mt: 2 }}>

--- a/src/renderer/services/strategies/Normal.ts
+++ b/src/renderer/services/strategies/Normal.ts
@@ -1,0 +1,17 @@
+import { Coin } from '../../../models';
+import * as config from '../AppSettingsService';
+
+function pickCoin(currentCoin: string, enabledCoins: Coin[]) {
+  const index = enabledCoins.findIndex((c) => c.symbol === currentCoin);
+
+  if (index === -1 || index === enabledCoins.length - 1) {
+    return enabledCoins[0];
+  }
+
+  return enabledCoins[index + 1];
+}
+
+export async function selectCoin(currentCoin: string | null) {
+  const enabledCoins = (await config.getCoins()).filter((c) => c.enabled).sort((a, b) => a.symbol.localeCompare(b.symbol));
+  return currentCoin === null ? enabledCoins[0] : pickCoin(currentCoin, enabledCoins);
+}

--- a/src/renderer/services/strategies/Normal.ts
+++ b/src/renderer/services/strategies/Normal.ts
@@ -1,5 +1,4 @@
 import { Coin } from '../../../models';
-import * as config from '../AppSettingsService';
 
 function pickCoin(currentCoin: string, enabledCoins: Coin[]) {
   const index = enabledCoins.findIndex((c) => c.symbol === currentCoin);
@@ -11,7 +10,7 @@ function pickCoin(currentCoin: string, enabledCoins: Coin[]) {
   return enabledCoins[index + 1];
 }
 
-export async function selectCoin(currentCoin: string | null) {
-  const enabledCoins = (await config.getCoins()).filter((c) => c.enabled).sort((a, b) => a.symbol.localeCompare(b.symbol));
-  return currentCoin === null ? enabledCoins[0] : pickCoin(currentCoin, enabledCoins);
+export function selectCoin(currentCoin: string | null, enabledCoins: Coin[]) {
+  const sortedCoins = [...enabledCoins].sort((a, b) => a.symbol.localeCompare(b.symbol));
+  return currentCoin === null ? sortedCoins[0] : pickCoin(currentCoin, sortedCoins);
 }

--- a/src/renderer/services/strategies/Skynet.ts
+++ b/src/renderer/services/strategies/Skynet.ts
@@ -1,0 +1,25 @@
+import { Coin } from '../../../models';
+import * as config from '../AppSettingsService';
+
+function getRandom<T>(array: Array<T>) {
+  return array[Math.floor(Math.random() * array.length)];
+}
+
+function getRandomCoin(currentCoin: string | null, coins: Coin[]): Coin {
+  if (coins.length === 1) {
+    return coins[0];
+  }
+
+  const newCoin = getRandom(coins);
+
+  if (currentCoin !== newCoin.symbol) {
+    return newCoin;
+  }
+
+  return getRandomCoin(currentCoin, coins);
+}
+
+export async function selectCoin(currentCoin: string | null) {
+  const enabledCoins = (await config.getCoins()).filter((c) => c.enabled);
+  return getRandomCoin(currentCoin, enabledCoins);
+}

--- a/src/renderer/services/strategies/Skynet.ts
+++ b/src/renderer/services/strategies/Skynet.ts
@@ -1,5 +1,4 @@
 import { Coin } from '../../../models';
-import * as config from '../AppSettingsService';
 
 function getRandom<T>(array: Array<T>) {
   return array[Math.floor(Math.random() * array.length)];
@@ -19,7 +18,6 @@ function getRandomCoin(currentCoin: string | null, coins: Coin[]): Coin {
   return getRandomCoin(currentCoin, coins);
 }
 
-export async function selectCoin(currentCoin: string | null) {
-  const enabledCoins = (await config.getCoins()).filter((c) => c.enabled);
+export function selectCoin(currentCoin: string | null, enabledCoins: Coin[]) {
   return getRandomCoin(currentCoin, enabledCoins);
 }

--- a/src/renderer/services/strategies/index.ts
+++ b/src/renderer/services/strategies/index.ts
@@ -1,0 +1,2 @@
+export { selectCoin as skynet } from './Skynet';
+export { selectCoin as normal } from './Normal';


### PR DESCRIPTION
Made the coin selection algorithm for the app configurable.  By default the app will now run coins sequentially on the list.  The app has a second strategy labeled `skynet` that allows it to decide which coin to run.  This is configurable through the `Settings` screen.

@evan-cohen Can you please take a look at the lightbulb placement for the new setting?  It looks a little off.  I think we should be locking the width of the drop-down to prevent this.