### PR TITLE
Added link to command line option reference in the EditMiner dialog.

### DIFF
--- a/src/models/MinerInfo.ts
+++ b/src/models/MinerInfo.ts
@@ -5,6 +5,7 @@ export type MinerInfo = {
   owner: string;
   repo: string;
   assetPattern: RegExp;
+  optionsUrl: string;
   algorithms: AlgorithmName[];
   exe: string;
   getArgs: (algorithm: AlgorithmName, cs: string, url: string) => string;
@@ -25,6 +26,7 @@ export const AVAILABLE_MINERS: MinerInfo[] = [
     owner: 'lolliedieb',
     repo: 'lolMiner-releases',
     assetPattern: /^.+Win64\.zip$/,
+    optionsUrl: 'https://lolminer.site/documentation/arguments/',
     exe: 'lolminer.exe',
     getArgs: (alg, cs, url) => `--algo ${alg.toLocaleUpperCase()} --pool ${url} --user ${cs} --nocolor --apiport ${API_PORT}`,
   },
@@ -34,6 +36,7 @@ export const AVAILABLE_MINERS: MinerInfo[] = [
     owner: 'NebuTech',
     repo: 'NBMiner',
     assetPattern: /^NBMiner.+_Win\.zip$/,
+    optionsUrl: 'https://nbminer.info/documentation/arguments/',
     exe: 'nbminer.exe',
     getArgs: (alg, cs, url) => `-a ${alg} -o stratum+tcp://${url} -u ${cs} --no-color --cmd-output 1 --api 127.0.0.1:60090`,
   },
@@ -43,6 +46,7 @@ export const AVAILABLE_MINERS: MinerInfo[] = [
     owner: 'trexminer',
     repo: 't-rex',
     assetPattern: /^t-rex-.+win.zip$/,
+    optionsUrl: 'https://trexminer.info/documentation/arguments/',
     exe: 't-rex.exe',
     getArgs: (alg, cs, url) => `-a ${alg} -o ${url} -u ${cs} -p x --api-bind-http 127.0.0.1:60090 --api-read-only --no-color`,
   },

--- a/src/renderer/dialogs/EditMinerDialog.tsx
+++ b/src/renderer/dialogs/EditMinerDialog.tsx
@@ -3,11 +3,13 @@
 import { useMemo, useState, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import Dialog from '@mui/material/Dialog';
-import { DialogTitle, DialogContent, TextField, Stack, MenuItem, FormControl, Divider } from '@mui/material';
+import { DialogTitle, DialogContent, TextField, Stack, MenuItem, FormControl, Divider, Button } from '@mui/material';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { AVAILABLE_ALGORITHMS, AVAILABLE_MINERS, Miner, MinerInfo, MinerRelease } from '../../models';
 import { AlgorithmMenuItem, MinerTypeMenuItem } from '../components';
 import { CustomDialogActions } from './CustomDialogActions';
 import { getMinerReleases } from '../services/DownloadManager';
+import { aboutApi } from '../../shared/AboutApi';
 
 type EditMinerDialogProps = {
   open: boolean;
@@ -89,6 +91,14 @@ export function EditMinerDialog(props: EditMinerDialogProps) {
     return current;
   };
 
+  const openReference = () => {
+    const currentMiner = availableMinersAsMinerInfo.find((m) => m.name === kind);
+
+    if (currentMiner !== undefined) {
+      aboutApi.openBrowser(currentMiner.optionsUrl);
+    }
+  };
+
   return (
     <Dialog sx={{ '& .MuiDialog-paper': { width: '500px' } }} open={open} {...other}>
       <DialogTitle sx={{ textAlign: 'center' }}>Edit Miner</DialogTitle>
@@ -132,7 +142,12 @@ export function EditMinerDialog(props: EditMinerDialogProps) {
                   </MenuItem>
                 ))}
               </TextField>
-              <TextField spellCheck="false" label="Parameters" {...register('parameters')} value={watch('parameters') ?? ''} />
+              <Stack direction="row" gap={1} alignItems="center">
+                <TextField style={{ width: '22rem' }} spellCheck="false" label="Parameters" {...register('parameters')} value={watch('parameters') ?? ''} />
+                <Button startIcon={<OpenInNewIcon />} size="small" variant="outlined" onClick={openReference}>
+                  Reference
+                </Button>
+              </Stack>
               <Divider />
               <CustomDialogActions buttonType="submit" onCancel={handleOnCancel} />
             </Stack>


### PR DESCRIPTION
Added a link titled 'Reference' next to the parameters `<TextField />` in the `EditMiner` screen.  When the user clicks on it a new browser window will open and direct them to the miner's command line options reference page.