### PR TITLE
Replaced the 'Next Coin' icon with FastForward.

### DIFF
--- a/src/renderer/screens/HomeScreen.tsx
+++ b/src/renderer/screens/HomeScreen.tsx
@@ -5,7 +5,7 @@ import { Container, Grid, Button, Typography } from '@mui/material';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import StopIcon from '@mui/icons-material/Stop';
 import RefreshIcon from '@mui/icons-material/Cached';
-import NextIcon from '@mui/icons-material/NavigateNext';
+import NextIcon from '@mui/icons-material/FastForward';
 
 // Services.
 import { GpuStatistic, MinerStatistic, ConfiguredCoin, minerState$, enabledCoins$, refreshData$ } from '../../models';


### PR DESCRIPTION
The `Next Coin` button in the `Home` screen was using the wrong icon.  Replaced the icon with the `FastForward` icon to be consistent with the lower toolbar.