### PR TITLE
Fixed mining buttons in Home screen on refresh

### DIFF
--- a/src/renderer/screens/HomeScreen.tsx
+++ b/src/renderer/screens/HomeScreen.tsx
@@ -8,7 +8,7 @@ import RefreshIcon from '@mui/icons-material/Cached';
 import NextIcon from '@mui/icons-material/FastForward';
 
 // Services.
-import { GpuStatistic, MinerStatistic, ConfiguredCoin, minerState$, enabledCoins$, refreshData$ } from '../../models';
+import { GpuStatistic, MinerStatistic, ConfiguredCoin, enabledCoins$, refreshData$ } from '../../models';
 import { startMiner, stopMiner, nextCoin } from '../services/MinerManager';
 import { UnmineableStats, unmineableWorkers$ } from '../services/UnmineableFeed';
 import { gpuStatistics$, minerStatistics$ } from '../services/StatisticsAggregator';
@@ -20,7 +20,6 @@ import { ScreenHeader } from '../components';
 import { CoinsTable, ComputeTable, MinerTable, WorkersGraphs } from '../components/dashboard';
 
 export function HomeScreen(): JSX.Element {
-  const [minerActive, setMinerActive] = useState(false);
   const [configuredCoins, setConfiguredCoins] = useState(Array<ConfiguredCoin>());
   const [currentGpuStats, setCurrentGpuStats] = useState(Array<GpuStatistic>());
   const [currentMinerStats, setCurrentMinerStats] = useState({} as MinerStatistic);
@@ -28,20 +27,20 @@ export function HomeScreen(): JSX.Element {
   const minerContext = useContext(MinerContext);
 
   useEffect(() => {
-    const minerSubscription = minerState$.subscribe((s) => setMinerActive(s.state === 'active'));
     const unmineableWorkersSubscription = unmineableWorkers$.subscribe((stats) => setWorkerStats(stats));
     const coinsSubscription = enabledCoins$.subscribe((coins) => setConfiguredCoins(coins));
     const gpuStatsSubscription = gpuStatistics$.subscribe((stats) => setCurrentGpuStats(stats));
     const minerStatsSubscription = minerStatistics$.subscribe((stats) => setCurrentMinerStats(stats));
 
     return () => {
-      minerSubscription.unsubscribe();
       unmineableWorkersSubscription.unsubscribe();
       coinsSubscription.unsubscribe();
       gpuStatsSubscription.unsubscribe();
       minerStatsSubscription.unsubscribe();
     };
   }, [minerContext.currentCoin]);
+
+  const minerActive = minerContext.state === 'active';
 
   return (
     <Container>

--- a/src/renderer/services/MinerManager.ts
+++ b/src/renderer/services/MinerManager.ts
@@ -164,7 +164,7 @@ async function setInitialState() {
   const defaultMiner = await getDefaultMiner(appSettings.settings.defaultMiner);
 
   if (minerState.state === 'active') {
-    updateState({ state: 'active', currentCoin: minerState.currentCoin, miner: minerState.miner });
+    updateState({ state: 'active', currentCoin: minerState.currentCoin, miner: minerState.miner, profile: minerState.profile });
   } else {
     updateState({ profile: defaultMiner?.name, miner: defaultMiner?.kind });
   }

--- a/src/shared/MinerApi.ts
+++ b/src/shared/MinerApi.ts
@@ -1,4 +1,4 @@
-import { MinerName } from '../models';
+import { MinerName, MinerState } from '../models';
 
 type ReceiveCallback = (data: string) => void;
 type ExitedCallback = (code: number | void) => void;
@@ -8,7 +8,7 @@ type ErrorCallback = (message: string) => void;
 export interface MinerApi {
   start: (profile: string, coin: string, miner: { name: MinerName; exe: string }, version: string, args: string) => Promise<string | null>;
   stop: () => Promise<void>;
-  status: () => Promise<{ state: 'active' | 'inactive'; currentCoin: string; miner: MinerName }>;
+  status: () => Promise<MinerState>;
   stats: (port: number, args: string) => Promise<string>;
   receive: (callback: ReceiveCallback) => Promise<void>;
   exited: (callback: ExitedCallback) => Promise<void>;


### PR DESCRIPTION
When refreshing the screen while mining was active the active profile would be dropped from the initial state.  This was causing the `disabled` check to fail for the buttons.

To fix I added `profile` when in `setInitialState()` even when active.

Also eliminated `minerState$` subscriptions from `HomeScreen` since this information is readily accessible via context.

Lastly, updated the return type for `minerApi.status()` since the module was already returning a completed object.