### PR TITLE
Dropped the 'best' column from the tables

### DIFF
--- a/src/renderer/components/dashboard/ComputeTable.tsx
+++ b/src/renderer/components/dashboard/ComputeTable.tsx
@@ -14,7 +14,6 @@ export function ComputeTable(props: { gpus: GpuStatistic[] }) {
             <TableCell>Name</TableCell>
             <TableCell>Hashrate</TableCell>
             <TableCell>Shares</TableCell>
-            <TableCell>Best</TableCell>
             <TableCell>Power</TableCell>
             <TableCell>Efficiency</TableCell>
             <TableCell>Core Clock</TableCell>
@@ -31,7 +30,6 @@ export function ComputeTable(props: { gpus: GpuStatistic[] }) {
               <TableCell>{gpu.name}</TableCell>
               <TableCell>{formatter.hashrate(gpu.hashrate)}</TableCell>
               <TableCell>{formatter.shares(gpu.accepted, gpu.rejected)}</TableCell>
-              <TableCell>{formatter.best(gpu.best)}</TableCell>
               <TableCell>{formatter.power(gpu.power)}</TableCell>
               <TableCell>{formatter.efficiency(gpu.efficiency)}</TableCell>
               <TableCell>{formatter.clockSpeed(gpu.coreClock)}</TableCell>

--- a/src/renderer/components/dashboard/MinerTable.tsx
+++ b/src/renderer/components/dashboard/MinerTable.tsx
@@ -4,7 +4,7 @@ import * as formatter from '../../services/Formatters';
 
 export function MinerTable(props: { miner: MinerStatistic }) {
   const { miner } = props;
-  const { hashrate, accepted, rejected, best, power, efficiency, difficulty, uptime } = miner;
+  const { hashrate, accepted, rejected, power, efficiency, difficulty, uptime } = miner;
 
   return (
     <TableContainer>
@@ -14,7 +14,6 @@ export function MinerTable(props: { miner: MinerStatistic }) {
             <TableCell>Hashrate</TableCell>
             <TableCell>Found</TableCell>
             <TableCell>Shares</TableCell>
-            <TableCell>Best</TableCell>
             <TableCell>Power</TableCell>
             <TableCell>Efficiency</TableCell>
             <TableCell>Difficulty</TableCell>
@@ -26,7 +25,6 @@ export function MinerTable(props: { miner: MinerStatistic }) {
             <TableCell>{formatter.hashrate(hashrate)}</TableCell>
             <TableCell>{formatter.found(accepted, rejected)}</TableCell>
             <TableCell>{formatter.shares(accepted, rejected)}</TableCell>
-            <TableCell>{formatter.best(best)}</TableCell>
             <TableCell>{formatter.power(power)}</TableCell>
             <TableCell>{formatter.efficiency(efficiency)}</TableCell>
             <TableCell>{formatter.difficulty(difficulty)}</TableCell>

--- a/src/renderer/services/Formatters.ts
+++ b/src/renderer/services/Formatters.ts
@@ -14,10 +14,6 @@ export function shares(accepted: number | undefined, rejected: number | undefine
   return `${number(accepted ?? 0)} / ${number(rejected ?? 0)}`;
 }
 
-export function best(value: string | undefined) {
-  return value === undefined ? 'N/A' : value;
-}
-
 export function found(accepted: number | undefined, rejected: number | undefined) {
   return number((accepted ?? 0) + (rejected ?? 0));
 }


### PR DESCRIPTION
The `Best` field is not used by most miners (only `lolminer`) and is largely informative (but otherwise useless).  Dropping it from the display to save real estate.