### PR TITLE
Wallets are now linked to coins via id.

### DIFF
--- a/src/renderer/dialogs/EditCoinDialog.tsx
+++ b/src/renderer/dialogs/EditCoinDialog.tsx
@@ -53,8 +53,8 @@ export function EditCoinDialog(props: EditCoinDialogProps) {
   const pickWallet = (current: string | null) => {
     if (current === null) {
       if (compatibleWallets.length > 0) {
-        setValue('wallet', compatibleWallets[0].name);
-        return compatibleWallets[0].name;
+        setValue('wallet', compatibleWallets[0].id);
+        return compatibleWallets[0].id;
       }
 
       return '';
@@ -99,7 +99,7 @@ export function EditCoinDialog(props: EditCoinDialogProps) {
                 {compatibleWallets
                   .sort((a, b) => a.name.localeCompare(b.name))
                   .map((w) => (
-                    <MenuItem key={w.name} value={w.name}>
+                    <MenuItem key={w.name} value={w.id}>
                       <WalletMenuItem wallet={w} />
                     </MenuItem>
                   ))}

--- a/src/renderer/screens/CoinsScreen.tsx
+++ b/src/renderer/screens/CoinsScreen.tsx
@@ -92,6 +92,15 @@ export function CoinsScreen() {
     setEnabledOnly(e.target.checked);
   };
 
+  const getWalletName = (id: string | null) => {
+    if (id === null) {
+      return 'None';
+    }
+
+    const wallet = wallets.find((w) => w.id === id);
+    return wallet?.name ?? '<unknown>';
+  };
+
   return (
     <Container>
       <ScreenHeader title="Coins">
@@ -132,7 +141,7 @@ export function CoinsScreen() {
                     <Chip key={`${c.name}-${chain}`} label={chain} />
                   ))}
                 </TableCell>
-                <TableCell>{c.coin.wallet ?? 'None'}</TableCell>
+                <TableCell>{getWalletName(c.coin.wallet)}</TableCell>
                 <TableCell>{formatter.duration(c.coin.duration)}</TableCell>
               </TableRow>
             ))}


### PR DESCRIPTION
Updated linking code so that wallets are tied to a coin by its id instead of its name.  Added additional check to differentiate between coins that aren't tied to any wallet (None) and coins that are tied to a wallet that can't be found (<unknown>).

## Mitigation Strategy
When opening up the coins screen for the first time any configured coin will report its wallet as `<unknown>`.  To fix the user will need to edit the coin and select the wallet from the drop-down.  This only needs to be done once per-coin to relink them to the correct wallet.  If the user attempts to mine the coin without doing this first they'll receive a (somewhat misleading) error saying that the wallet could not be found.

@evan-cohen What are your thoughts on this?  I think it's a reasonable compromise since this is a pre-release and the alternatives are very hackish.