### PR TITLE
Fixed binding for wallet field.

### DIFF
--- a/src/renderer/services/DataService.ts
+++ b/src/renderer/services/DataService.ts
@@ -69,7 +69,7 @@ function reloadCoins(coins: Coin[]) {
       .filter((c) => c.enabled)
       .map((c) => {
         const cd = ALL_COINS.find((x) => x.symbol === c.symbol);
-        const wallet = wallets.find((w) => c.wallet === w.name);
+        const wallet = wallets.find((w) => c.wallet === w.id);
 
         const previousCoin = previouslyLoadedCoins.find((x) => x.symbol === c.symbol);
         return {
@@ -110,7 +110,7 @@ export async function enableDataService() {
   enabledCoins$.next(
     loadedCoins.map((c) => {
       const cd = ALL_COINS.find((x) => x.symbol === c.symbol);
-      const wallet = wallets.find((w) => c.wallet === w.name);
+      const wallet = wallets.find((w) => c.wallet === w.id);
 
       return {
         current: false,


### PR DESCRIPTION
When refreshing the `enabledCoins$` observable, the wallet linking was still being done via name.  This was causing a miss and preventing the `address` field from being mapped properly.  As a result the refresh call to unmineable was failing with a 404 error.