### PR TITLE
Fixed broken delete wallet button

### DIFF
--- a/src/renderer/dialogs/RemoveWalletDialog.tsx
+++ b/src/renderer/dialogs/RemoveWalletDialog.tsx
@@ -27,7 +27,7 @@ export function RemoveWalletDialog(props: RemoveWalletDialogProps) {
         </Typography>
         <UsedByCoins coins={coins} />
         <Divider />
-        <CustomDialogActions buttonType="submit" buttonText="Yes" onConfirm={() => () => onRemove(name, id)} secondaryButtonText="No" onCancel={onCancel} primaryButtonDisabled={isUsedByCoins > 0} />
+        <CustomDialogActions buttonType="submit" buttonText="Yes" onConfirm={() => onRemove(name, id)} secondaryButtonText="No" onCancel={onCancel} primaryButtonDisabled={isUsedByCoins > 0} />
       </DialogContent>
     </Dialog>
   );


### PR DESCRIPTION
The `Yes` button on the delete wallet confirmation dialog wasn't wired up properly.  Looks like it may have been a merge anomaly.