### PR TITLE
Modularize Home Screen

### DIFF
--- a/src/renderer/components/dashboard/CoinsTable.tsx
+++ b/src/renderer/components/dashboard/CoinsTable.tsx
@@ -43,6 +43,10 @@ function CurrentIndicator(props: CurrentIndicatorProps) {
 export function CoinsTable() {
   const [coins] = useObservableState(enabledCoins$, []);
 
+  if (coins.length === 0) {
+    return <p>No configured coins.</p>;
+  }
+
   return (
     <TableContainer>
       <Table>

--- a/src/renderer/components/dashboard/CoinsTable.tsx
+++ b/src/renderer/components/dashboard/CoinsTable.tsx
@@ -3,14 +3,10 @@ import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import StopIcon from '@mui/icons-material/Stop';
 import { LinearProgressWithLabel } from '..';
 import * as formatter from '../../services/Formatters';
+import { nextCoin, stopMiner } from '../../services/MinerManager';
 import { enabledCoins$ } from '../../../models';
 import { unmineableApi } from '../../../shared/UnmineableApi';
 import { useObservableState } from '../../hooks';
-
-type CoinsTableProps = {
-  setCurrent: (coin: string) => void;
-  stopCurrent: () => void;
-};
 
 type CurrentIndicatorProps = {
   current: boolean;
@@ -44,8 +40,7 @@ function CurrentIndicator(props: CurrentIndicatorProps) {
   );
 }
 
-export function CoinsTable(props: CoinsTableProps) {
-  const { setCurrent, stopCurrent } = props;
+export function CoinsTable() {
   const [coins] = useObservableState(enabledCoins$, []);
 
   return (
@@ -69,7 +64,7 @@ export function CoinsTable(props: CoinsTableProps) {
             .map((c) => (
               <TableRow key={c.symbol}>
                 <TableCell>
-                  <CurrentIndicator current={c.current} onStart={() => setCurrent(c.symbol)} onStop={() => stopCurrent()} />
+                  <CurrentIndicator current={c.current} onStart={() => nextCoin(c.symbol)} onStop={() => stopMiner()} />
                 </TableCell>
                 <TableCell>
                   <Button onClick={async () => openBrowser(c.symbol, c.address)} sx={{ minWidth: '5rem' }}>

--- a/src/renderer/components/dashboard/CoinsTable.tsx
+++ b/src/renderer/components/dashboard/CoinsTable.tsx
@@ -1,4 +1,4 @@
-import { Button, Table, TableContainer, TableCell, TableHead, TableRow, TableBody, Tooltip, IconButton } from '@mui/material';
+import { Button, Table, TableContainer, TableCell, TableHead, TableRow, TableBody, Tooltip, IconButton, Typography } from '@mui/material';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import StopIcon from '@mui/icons-material/Stop';
 import { LinearProgressWithLabel } from '..';
@@ -44,7 +44,7 @@ export function CoinsTable() {
   const [coins] = useObservableState(enabledCoins$, []);
 
   if (coins.length === 0) {
-    return <p>No configured coins.</p>;
+    return <Typography>No configured coins.</Typography>;
   }
 
   return (

--- a/src/renderer/components/dashboard/ComputeTable.tsx
+++ b/src/renderer/components/dashboard/ComputeTable.tsx
@@ -1,4 +1,4 @@
-import { Table, TableContainer, TableCell, TableHead, TableRow, TableBody } from '@mui/material';
+import { Table, TableContainer, TableCell, TableHead, TableRow, TableBody, Typography } from '@mui/material';
 import * as formatter from '../../services/Formatters';
 import { gpuStatistics$ } from '../../services/StatisticsAggregator';
 import { useObservableState } from '../../hooks';
@@ -7,7 +7,7 @@ export function ComputeTable() {
   const [gpus] = useObservableState(gpuStatistics$, []);
 
   if (gpus.length === 0) {
-    return <p>No data to display!</p>;
+    return <Typography>No data to display!</Typography>;
   }
 
   return (

--- a/src/renderer/components/dashboard/ComputeTable.tsx
+++ b/src/renderer/components/dashboard/ComputeTable.tsx
@@ -6,6 +6,10 @@ import { useObservableState } from '../../hooks';
 export function ComputeTable() {
   const [gpus] = useObservableState(gpuStatistics$, []);
 
+  if (gpus.length === 0) {
+    return <p>No data to display!</p>;
+  }
+
   return (
     <TableContainer>
       <Table>

--- a/src/renderer/components/dashboard/MinerTable.tsx
+++ b/src/renderer/components/dashboard/MinerTable.tsx
@@ -1,4 +1,4 @@
-import { Table, TableContainer, TableCell, TableHead, TableRow, TableBody } from '@mui/material';
+import { Table, TableContainer, TableCell, TableHead, TableRow, TableBody, Typography } from '@mui/material';
 import * as formatter from '../../services/Formatters';
 import { minerStatistics$ } from '../../services/StatisticsAggregator';
 import { useObservableState } from '../../hooks';
@@ -8,7 +8,7 @@ export function MinerTable() {
   const { hashrate, accepted, rejected, power, efficiency, difficulty, uptime } = miner ?? {};
 
   if (miner === null || Object.values(miner).find((x) => x !== undefined) === undefined) {
-    return <p>No data to display!</p>;
+    return <Typography>No data to display!</Typography>;
   }
 
   return (

--- a/src/renderer/components/dashboard/MinerTable.tsx
+++ b/src/renderer/components/dashboard/MinerTable.tsx
@@ -7,6 +7,10 @@ export function MinerTable() {
   const [miner] = useObservableState(minerStatistics$, null);
   const { hashrate, accepted, rejected, power, efficiency, difficulty, uptime } = miner ?? {};
 
+  if (miner === null || Object.values(miner).find((x) => x !== undefined) === undefined) {
+    return <p>No data to display!</p>;
+  }
+
   return (
     <TableContainer>
       <Table>

--- a/src/renderer/components/dashboard/WorkersGraphs.tsx
+++ b/src/renderer/components/dashboard/WorkersGraphs.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 
 import dateFormat from 'dateformat';
-import { Chart as ChartJS, CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend } from 'chart.js';
+import { Chart as ChartJS, CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend, Typography } from 'chart.js';
 import { Line } from 'react-chartjs-2';
 
 import { Tabs, Tab } from '@mui/material';
@@ -23,7 +23,7 @@ function WorkersGraph(props: { algorithm: string; stat: AlgorithmStat | undefine
   const { algorithm, stat } = props;
 
   if (stat === undefined || stat.workers === undefined || stat.chart === undefined) {
-    return <p>No data to display!</p>;
+    return <Typography>No data to display!</Typography>;
   }
 
   const options = {

--- a/src/renderer/components/dashboard/WorkersGraphs.tsx
+++ b/src/renderer/components/dashboard/WorkersGraphs.tsx
@@ -1,10 +1,10 @@
 import { useState, useEffect } from 'react';
 
 import dateFormat from 'dateformat';
-import { Chart as ChartJS, CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend, Typography } from 'chart.js';
+import { Chart as ChartJS, CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend } from 'chart.js';
 import { Line } from 'react-chartjs-2';
 
-import { Tabs, Tab } from '@mui/material';
+import { Tabs, Tab, Typography } from '@mui/material';
 import { TabPanel } from '..';
 import { AlgorithmStat, unmineableWorkers$ } from '../../services/UnmineableFeed';
 import { useObservableState } from '../../hooks';

--- a/src/renderer/screens/HomeScreen.tsx
+++ b/src/renderer/screens/HomeScreen.tsx
@@ -1,9 +1,10 @@
 // UI.
-import { Container, Grid, Button, Typography } from '@mui/material';
+import { Container, Button, Typography, Accordion, AccordionSummary, AccordionDetails } from '@mui/material';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import StopIcon from '@mui/icons-material/Stop';
 import RefreshIcon from '@mui/icons-material/Cached';
 import NextIcon from '@mui/icons-material/FastForward';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMOre';
 
 // Services.
 import { refreshData$, minerState$ } from '../../models';
@@ -24,16 +25,16 @@ export function HomeScreen(): JSX.Element {
 
   const dashboards = [
     {
+      header: 'Coins',
+      component: <CoinsTable />,
+    },
+    {
       header: 'GPUs',
       component: <ComputeTable />,
     },
     {
       header: 'General',
       component: <MinerTable />,
-    },
-    {
-      header: 'Enabled Coins',
-      component: <CoinsTable />,
     },
     {
       header: 'Graphs',
@@ -57,14 +58,14 @@ export function HomeScreen(): JSX.Element {
           Refresh
         </Button>
       </ScreenHeader>
-      <Grid container spacing={4}>
-        {dashboards.map((d) => (
-          <Grid item xs={12}>
+      {dashboards.map((d) => (
+        <Accordion defaultExpanded>
+          <AccordionSummary expandIcon={<ExpandMoreIcon />} aria-controls="panel1a-content" id="panel1a-header">
             <Typography variant="h5">{d.header}</Typography>
-            {d.component}
-          </Grid>
-        ))}
-      </Grid>
+          </AccordionSummary>
+          <AccordionDetails>{d.component}</AccordionDetails>
+        </Accordion>
+      ))}
     </Container>
   );
 }

--- a/src/renderer/screens/HomeScreen.tsx
+++ b/src/renderer/screens/HomeScreen.tsx
@@ -4,7 +4,7 @@ import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import StopIcon from '@mui/icons-material/Stop';
 import RefreshIcon from '@mui/icons-material/Cached';
 import NextIcon from '@mui/icons-material/FastForward';
-import ExpandMoreIcon from '@mui/icons-material/ExpandMOre';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 
 // Services.
 import { refreshData$, minerState$ } from '../../models';

--- a/src/renderer/screens/HomeScreen.tsx
+++ b/src/renderer/screens/HomeScreen.tsx
@@ -59,7 +59,7 @@ export function HomeScreen(): JSX.Element {
         </Button>
       </ScreenHeader>
       {dashboards.map((d) => (
-        <Accordion defaultExpanded>
+        <Accordion key={d.header} defaultExpanded>
           <AccordionSummary expandIcon={<ExpandMoreIcon />} aria-controls="panel1a-content" id="panel1a-header">
             <Typography variant="h5">{d.header}</Typography>
           </AccordionSummary>

--- a/src/renderer/screens/HomeScreen.tsx
+++ b/src/renderer/screens/HomeScreen.tsx
@@ -22,6 +22,25 @@ export function HomeScreen(): JSX.Element {
   const profile = useProfile();
   const minerActive = minerState?.state === 'active';
 
+  const dashboards = [
+    {
+      header: 'GPUs',
+      component: <ComputeTable />,
+    },
+    {
+      header: 'General',
+      component: <MinerTable />,
+    },
+    {
+      header: 'Enabled Coins',
+      component: <CoinsTable />,
+    },
+    {
+      header: 'Graphs',
+      component: <WorkersGraphs />,
+    },
+  ];
+
   return (
     <Container>
       <ScreenHeader title="Home">
@@ -39,22 +58,12 @@ export function HomeScreen(): JSX.Element {
         </Button>
       </ScreenHeader>
       <Grid container spacing={4}>
-        <Grid item xs={12}>
-          <Typography variant="h5">GPUs</Typography>
-          <ComputeTable />
-        </Grid>
-        <Grid item xs={12}>
-          <Typography variant="h5">General</Typography>
-          <MinerTable />
-        </Grid>
-        <Grid item xs={12}>
-          <Typography variant="h5">Enabled Coins</Typography>
-          <CoinsTable setCurrent={(symbol) => nextCoin(symbol)} stopCurrent={stopMiner} />
-        </Grid>
-        <Grid item xs={12}>
-          <Typography variant="h5">Graphs</Typography>
-          <WorkersGraphs />
-        </Grid>
+        {dashboards.map((d) => (
+          <Grid item xs={12}>
+            <Typography variant="h5">{d.header}</Typography>
+            {d.component}
+          </Grid>
+        ))}
       </Grid>
     </Container>
   );


### PR DESCRIPTION
Dashboard elements in the home screen is now rendered as a list of components.  Also changed the rendering strategy to render each component as a separate `<Accordion />` so that elements can be hidden (all expanded by default).

Coins is now first on the list so that stats can be viewed together, followed by GPU/CPU stats, overall stats, and  worker graphs.

Lastly updated the dashboard components to return a placeholder message if there is no data to render.

@evan-cohen What are your thoughts on using `<p />` for placeholder text?  Should we be using `<Typography />` instead?

NOTE: The list of components is currently hard-coded, but with the inclusion of CPU mining support the logic will be tweaked to selectively filter components dynamically.