### PR TITLE
Fixed name collision when searching for miner release versions.

### DIFF
--- a/src/renderer/dialogs/EditMinerDialog.tsx
+++ b/src/renderer/dialogs/EditMinerDialog.tsx
@@ -10,6 +10,7 @@ import { AlgorithmMenuItem, MinerTypeMenuItem } from '../components';
 import { CustomDialogActions } from './CustomDialogActions';
 import { aboutApi } from '../../shared/AboutApi';
 import { useLoadData } from '../hooks';
+import { getMinerReleases as getMinerReleasesOnline } from '../services/DownloadManager';
 
 type EditMinerDialogProps = {
   open: boolean;
@@ -51,7 +52,13 @@ export function EditMinerDialog(props: EditMinerDialogProps) {
   }, [availableMiners]);
 
   useLoadData(async ({ getMinerReleases }) => {
-    setAvailableMiners(await getMinerReleases());
+    const onlineMiners = await getMinerReleasesOnline();
+
+    if (onlineMiners.length > 0) {
+      setAvailableMiners(onlineMiners);
+    } else {
+      setAvailableMiners(await getMinerReleases());
+    }
   });
 
   const handleOnSave = handleSubmit((val) => {


### PR DESCRIPTION
Major break in the application.  When the application first starts it should attempt to load miner releases from github and fall back to the cached `config.json` only if it fails.  Due to name collisions however it was only querying `config.json`.  As a result, new installations would haver no miner release history.  This prevented preconfigured miners from being modified or new miners from being added.