### PR TITLE
Refactor growl notifications

### DIFF
--- a/src/models/Observables.ts
+++ b/src/models/Observables.ts
@@ -1,7 +1,9 @@
+import { VariantType } from 'notistack';
 import { BehaviorSubject, Subject } from 'rxjs';
 import { ConfiguredCoin } from './ConfiguredCoin';
 import { MinerState } from './MinerState';
 
+export const appNotice$ = new Subject<{ variant: VariantType; message: string }>();
 export const minerErrors$ = new Subject<string>();
 export const minerState$ = new BehaviorSubject<MinerState>({ state: 'inactive', currentCoin: null });
 export const enabledCoins$ = new BehaviorSubject<ConfiguredCoin[]>([]);

--- a/src/models/Observables.ts
+++ b/src/models/Observables.ts
@@ -2,8 +2,13 @@ import { BehaviorSubject, Subject } from 'rxjs';
 import { ConfiguredCoin } from './ConfiguredCoin';
 import { MinerState } from './MinerState';
 
-export const appNotice$ = new Subject<{ variant: 'default' | 'error' | 'success' | 'warning' | 'info'; message: string }>();
-export const minerErrors$ = new Subject<string>();
+type VariantType = 'default' | 'error' | 'success' | 'warning' | 'info';
+
+export const appNotice$ = new Subject<{ variant: VariantType; message: string }>();
 export const minerState$ = new BehaviorSubject<MinerState>({ state: 'inactive', currentCoin: null });
 export const enabledCoins$ = new BehaviorSubject<ConfiguredCoin[]>([]);
 export const refreshData$ = new Subject<number>();
+
+export function addAppNotice(variant: VariantType, message: string) {
+  appNotice$.next({ variant, message });
+}

--- a/src/models/Observables.ts
+++ b/src/models/Observables.ts
@@ -1,9 +1,8 @@
-import { VariantType } from 'notistack';
 import { BehaviorSubject, Subject } from 'rxjs';
 import { ConfiguredCoin } from './ConfiguredCoin';
 import { MinerState } from './MinerState';
 
-export const appNotice$ = new Subject<{ variant: VariantType; message: string }>();
+export const appNotice$ = new Subject<{ variant: 'default' | 'error' | 'success' | 'warning' | 'info'; message: string }>();
 export const minerErrors$ = new Subject<string>();
 export const minerState$ = new BehaviorSubject<MinerState>({ state: 'inactive', currentCoin: null });
 export const enabledCoins$ = new BehaviorSubject<ConfiguredCoin[]>([]);

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -11,6 +11,6 @@ export { MinerInfo, AVAILABLE_MINERS } from './MinerInfo';
 export { GpuStatistic, MinerStatistic } from './Aggregates';
 export { ConfiguredCoin } from './ConfiguredCoin';
 export { MinerState } from './MinerState';
-export { minerErrors$, minerState$, enabledCoins$, refreshData$ } from './Observables';
+export { appNotice$, minerErrors$, minerState$, enabledCoins$, refreshData$ } from './Observables';
 export { DefaultSettings, SettingsSchemaType } from './DefaultSettings';
 export { MinerRelease } from './MinerRelease';

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -11,6 +11,6 @@ export { MinerInfo, AVAILABLE_MINERS } from './MinerInfo';
 export { GpuStatistic, MinerStatistic } from './Aggregates';
 export { ConfiguredCoin } from './ConfiguredCoin';
 export { MinerState } from './MinerState';
-export { appNotice$, minerErrors$, minerState$, enabledCoins$, refreshData$ } from './Observables';
+export { appNotice$, minerState$, enabledCoins$, refreshData$, addAppNotice } from './Observables';
 export { DefaultSettings, SettingsSchemaType } from './DefaultSettings';
 export { MinerRelease } from './MinerRelease';

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -22,7 +22,7 @@ import SettingsIcon from '@mui/icons-material/Settings';
 import InfoIcon from '@mui/icons-material/Info';
 
 import { Toolbar } from './components/Toolbar';
-import { minerErrors$, appNotice$ } from '../models';
+import { appNotice$, addAppNotice } from '../models';
 import { useObservable } from './hooks';
 import { HomeScreen, WalletsScreen, CoinsScreen, MinersScreen, MonitorScreen, SettingsScreen, AboutScreen } from './screens';
 import { minerExited$, minerStarted$ } from './services/MinerService';
@@ -72,9 +72,8 @@ function AppContent() {
   const { enqueueSnackbar } = useSnackbar();
 
   useObservable(appNotice$, ({ variant, message }) => enqueueSnackbar(message, { variant }));
-  useObservable(minerStarted$, ({ coin }) => appNotice$.next({ variant: 'success', message: `Miner is now mining ${coin}` }));
-  useObservable(minerExited$, () => appNotice$.next({ variant: 'default', message: 'Miner exited.' }));
-  useObservable(minerErrors$, (s) => appNotice$.next({ variant: 'error', message: s }));
+  useObservable(minerStarted$, ({ coin }) => addAppNotice('success', `Miner is now mining ${coin}`));
+  useObservable(minerExited$, () => addAppNotice('default', 'Miner exited.'));
 
   return (
     <Router>

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -22,7 +22,7 @@ import SettingsIcon from '@mui/icons-material/Settings';
 import InfoIcon from '@mui/icons-material/Info';
 
 import { Toolbar } from './components/Toolbar';
-import { minerErrors$ } from '../models';
+import { minerErrors$, appNotice$ } from '../models';
 import { useObservable } from './hooks';
 import { HomeScreen, WalletsScreen, CoinsScreen, MinersScreen, MonitorScreen, SettingsScreen, AboutScreen } from './screens';
 import { minerExited$, minerStarted$ } from './services/MinerService';
@@ -71,9 +71,10 @@ function safeReverse<T>(items: Array<T>) {
 function AppContent() {
   const { enqueueSnackbar } = useSnackbar();
 
-  useObservable(minerStarted$, ({ coin }) => enqueueSnackbar(`Miner is now mining ${coin}`));
-  useObservable(minerExited$, () => enqueueSnackbar('Miner exited.'));
-  useObservable(minerErrors$, (s) => enqueueSnackbar(s, { variant: 'error' }));
+  useObservable(appNotice$, ({ variant, message }) => enqueueSnackbar(message, { variant }));
+  useObservable(minerStarted$, ({ coin }) => appNotice$.next({ variant: 'success', message: `Miner is now mining ${coin}` }));
+  useObservable(minerExited$, () => appNotice$.next({ variant: 'default', message: 'Miner exited.' }));
+  useObservable(minerErrors$, (s) => appNotice$.next({ variant: 'error', message: s }));
 
   return (
     <Router>

--- a/src/renderer/services/DownloadManager.ts
+++ b/src/renderer/services/DownloadManager.ts
@@ -1,5 +1,5 @@
 import AsyncLock from 'async-lock';
-import { AVAILABLE_MINERS, MinerInfo, MinerRelease } from '../../models';
+import { AVAILABLE_MINERS, MinerInfo, MinerRelease, addAppNotice } from '../../models';
 import { downloadApi } from '../../shared/DownloadApi';
 import * as config from './AppSettingsService';
 
@@ -69,5 +69,6 @@ export async function downloadMiner(name: string, version: string) {
     return downloadApi.downloadMiner(name, version, url);
   }
 
+  addAppNotice('error', `Unable to download miner '${name}': URL for version ${version} not found.`);
   return false;
 }

--- a/src/renderer/services/MinerManager.ts
+++ b/src/renderer/services/MinerManager.ts
@@ -3,7 +3,7 @@ import path from 'path-browserify';
 import * as miningService from './MinerService';
 import * as config from './AppSettingsService';
 import { minerApi } from '../../shared/MinerApi';
-import { ALL_COINS, CoinDefinition, AVAILABLE_MINERS, Miner, Coin, MinerInfo, Wallet, MinerState, minerState$, minerErrors$ } from '../../models';
+import { ALL_COINS, CoinDefinition, AVAILABLE_MINERS, Miner, Coin, MinerInfo, Wallet, MinerState, minerState$, addAppNotice } from '../../models';
 import { getMiners, getAppSettings, watchers$ as settingsWatcher$ } from './AppSettingsService';
 import { downloadMiner } from './DownloadManager';
 import * as coinStrategy from './strategies';
@@ -98,7 +98,7 @@ async function changeCoin(symbol: string | null) {
   selectCoin(
     symbol,
     (error) => {
-      minerErrors$.next(error);
+      addAppNotice('error', error);
     },
     async (selection) => {
       const appSettings = await config.getAppSettings();

--- a/src/renderer/services/MinerService.ts
+++ b/src/renderer/services/MinerService.ts
@@ -1,6 +1,6 @@
 import { Subject } from 'rxjs';
 import { minerApi } from '../../shared/MinerApi';
-import { minerErrors$, MinerInfo } from '../../models';
+import { addAppNotice, MinerInfo } from '../../models';
 
 export const stdout$ = new Subject<string>();
 export const minerExited$ = new Subject<number | void>();
@@ -11,7 +11,7 @@ export async function startMiner(profile: string, coin: string, miner: MinerInfo
   const error = await minerApi.start(profile, coin, { name: miner.name, exe: miner.exe }, version, args);
 
   if (error !== null) {
-    minerErrors$.next(error);
+    addAppNotice('error', error);
   }
 }
 
@@ -45,5 +45,5 @@ minerApi.exited((code: number | void) => {
 });
 
 minerApi.error((message: string) => {
-  minerErrors$.next(message);
+  addAppNotice('error', message);
 });


### PR DESCRIPTION
Added `appNotice$` observable to service code to render growl notifications of any type.  Refactored `App.tsx` so that `minerStarted$`, `minerExited$`, and `minerError$` and feed into `appNotice$`.