### PR TITLE
Miner version info is now reset properly if it has a bad value

### DIFF
--- a/src/renderer/dialogs/EditMinerDialog.tsx
+++ b/src/renderer/dialogs/EditMinerDialog.tsx
@@ -62,10 +62,12 @@ export function EditMinerDialog(props: EditMinerDialogProps) {
   });
 
   const handleOnSave = handleSubmit((val) => {
-    if (watch('version') === '') {
+    const version = watch('version');
+
+    if (version === '' || minerTypeVersions.includes(version) === false) {
       onSave({ ...val, id: miner.id, version: minerTypeVersions[0] });
     } else {
-      onSave({ ...val, id: miner.id });
+      onSave({ ...val, id: miner.id, version });
     }
 
     if (autoReset) {


### PR DESCRIPTION
When changing miners the version number would not change automatically unless explicitly set.  Added additional logic to force it to reset to the latest version if the value is either omitted or not in the acceptable range.