### PR TITLE
Removed support for ethash algorithm.

### DIFF
--- a/src/__tests__/hooks/profile.tests.ts
+++ b/src/__tests__/hooks/profile.tests.ts
@@ -16,7 +16,6 @@ describe('Profile Hook', () => {
       theme: 'light',
     },
     pools: {
-      ethash: '',
       etchash: '',
       kawpow: '',
       autolykos2: '',
@@ -49,7 +48,6 @@ describe('Profile Hook', () => {
         theme: 'light',
       },
       pools: {
-        ethash: '',
         etchash: '',
         kawpow: '',
         autolykos2: '',

--- a/src/__tests__/services/AppSettingsService.tests.ts
+++ b/src/__tests__/services/AppSettingsService.tests.ts
@@ -57,7 +57,7 @@ describe('App Settings Service', () => {
           kind: 'lolminer',
           name: 'miner',
           version: '',
-          algorithm: 'ethash',
+          algorithm: 'etchash',
           parameters: '',
         },
       ];
@@ -83,7 +83,6 @@ describe('App Settings Service', () => {
           proxy: '',
         },
         pools: {
-          ethash: '',
           etchash: '',
           kawpow: '',
           autolykos2: '',

--- a/src/main/globals.ts
+++ b/src/main/globals.ts
@@ -26,9 +26,9 @@ export const globalStore = new Store<SettingsSchemaType>({
         pools: {
           type: 'object',
           properties: {
-            ethash: { type: 'string' },
             etchash: { type: 'string' },
             kawpow: { type: 'string' },
+            autolykos2: { type: 'string' },
             randomx: { type: 'string' },
           },
           required: [],

--- a/src/models/AlgorithmInfo.ts
+++ b/src/models/AlgorithmInfo.ts
@@ -7,10 +7,6 @@ export type AlgorithmInfo = {
 
 export const AVAILABLE_ALGORITHMS: AlgorithmInfo[] = [
   {
-    name: 'ethash',
-    kind: 'GPU',
-  },
-  {
     name: 'etchash',
     kind: 'GPU',
   },

--- a/src/models/AppSettings.ts
+++ b/src/models/AppSettings.ts
@@ -15,7 +15,6 @@ export type AppSettings = {
   settings: GeneralSettings;
   appearance: AppearanceSettings;
   pools: {
-    ethash: string;
     etchash: string;
     kawpow: string;
     autolykos2: string;

--- a/src/models/DefaultSettings.ts
+++ b/src/models/DefaultSettings.ts
@@ -16,9 +16,9 @@ export const DefaultSettings: SettingsSchemaType = {
   wallets: [],
   coins: [],
   miners: [
-    { id: '5d81682a-50e4-452c-a8cc-cfa516b3c667', kind: 'nbminer', name: 'nbminer', version: 'v41.5', algorithm: 'ethash', parameters: '' },
-    { id: '4dbc2b17-348f-4529-859a-7bcdfca20e1e', kind: 'lolminer', name: 'lolminer', version: '1.50', algorithm: 'ethash', parameters: '' },
-    { id: 'e76609d0-7823-4c17-bb13-17d0ef61f717', kind: 'trexminer', name: 'trexminer', version: '0.26.1', algorithm: 'ethash', parameters: '' },
+    { id: '5d81682a-50e4-452c-a8cc-cfa516b3c667', kind: 'nbminer', name: 'nbminer', version: 'v41.5', algorithm: 'etchash', parameters: '' },
+    { id: '4dbc2b17-348f-4529-859a-7bcdfca20e1e', kind: 'lolminer', name: 'lolminer', version: '1.50', algorithm: 'etchash', parameters: '' },
+    { id: 'e76609d0-7823-4c17-bb13-17d0ef61f717', kind: 'trexminer', name: 'trexminer', version: '0.26.1', algorithm: 'etchash', parameters: '' },
   ],
   settings: {
     settings: {
@@ -28,7 +28,6 @@ export const DefaultSettings: SettingsSchemaType = {
       proxy: '',
     },
     pools: {
-      ethash: 'ethash.unmineable.com:3333',
       etchash: 'etchash.unmineable.com:3333',
       kawpow: 'kp.unmineable.com:3333',
       autolykos2: 'autolykos.unmineable.com:3333',

--- a/src/models/Enums.ts
+++ b/src/models/Enums.ts
@@ -2,5 +2,5 @@ export const API_PORT = 60090;
 
 export type MinerName = 'phoenixminer' | 'lolminer' | 'nbminer' | 'trexminer' | 'xmrig';
 export type AlgorithmKind = 'CPU' | 'GPU';
-export type AlgorithmName = 'ethash' | 'etchash' | 'kawpow' | 'autolykos2' | 'randomx';
+export type AlgorithmName = 'etchash' | 'kawpow' | 'autolykos2' | 'randomx';
 export type CoinSelectionStrategy = 'normal' | 'skynet';

--- a/src/models/MinerInfo.ts
+++ b/src/models/MinerInfo.ts
@@ -22,7 +22,7 @@ export const AVAILABLE_MINERS: MinerInfo[] = [
   // },
   {
     name: 'lolminer',
-    algorithms: ['ethash', 'etchash', 'autolykos2'],
+    algorithms: ['etchash', 'autolykos2'],
     owner: 'lolliedieb',
     repo: 'lolMiner-releases',
     assetPattern: /^.+Win64\.zip$/,
@@ -32,7 +32,7 @@ export const AVAILABLE_MINERS: MinerInfo[] = [
   },
   {
     name: 'nbminer',
-    algorithms: ['ethash', 'etchash', 'kawpow', 'autolykos2'],
+    algorithms: ['etchash', 'kawpow', 'autolykos2'],
     owner: 'NebuTech',
     repo: 'NBMiner',
     assetPattern: /^NBMiner.+_Win\.zip$/,
@@ -42,7 +42,7 @@ export const AVAILABLE_MINERS: MinerInfo[] = [
   },
   {
     name: 'trexminer',
-    algorithms: ['ethash', 'etchash', 'kawpow', 'autolykos2'],
+    algorithms: ['etchash', 'kawpow', 'autolykos2'],
     owner: 'trexminer',
     repo: 't-rex',
     assetPattern: /^t-rex-.+win.zip$/,

--- a/src/renderer/components/dashboard/WorkersGraphs.tsx
+++ b/src/renderer/components/dashboard/WorkersGraphs.tsx
@@ -103,7 +103,6 @@ export function WorkersGraphs() {
   return (
     <div>
       <Tabs value={tabIndex} onChange={tabClicked}>
-        <Tab label="Ethash" />
         <Tab label="Etchash" />
         <Tab label="Kawpow" />
         <Tab label="Autolykos" />
@@ -111,15 +110,12 @@ export function WorkersGraphs() {
       </Tabs>
 
       <TabPanel value={tabIndex} index={0}>
-        <WorkersGraph algorithm="Ethash" stat={workers?.ethash} />
-      </TabPanel>
-      <TabPanel value={tabIndex} index={1}>
         <WorkersGraph algorithm="Etchash" stat={workers?.etchash} />
       </TabPanel>
-      <TabPanel value={tabIndex} index={2}>
+      <TabPanel value={tabIndex} index={1}>
         <WorkersGraph algorithm="Kawpow" stat={workers?.kawpow} />
       </TabPanel>
-      <TabPanel value={tabIndex} index={3}>
+      <TabPanel value={tabIndex} index={2}>
         <WorkersGraph algorithm="Autolykos" stat={workers?.autolykos} />
       </TabPanel>
       <TabPanel value={tabIndex} index={3}>

--- a/src/renderer/dialogs/EditMinerDialog.tsx
+++ b/src/renderer/dialogs/EditMinerDialog.tsx
@@ -5,7 +5,7 @@ import { useForm } from 'react-hook-form';
 import Dialog from '@mui/material/Dialog';
 import { DialogTitle, DialogContent, TextField, Stack, MenuItem, FormControl, Divider, Button } from '@mui/material';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
-import { AVAILABLE_ALGORITHMS, AVAILABLE_MINERS, Miner, MinerInfo, MinerRelease } from '../../models';
+import { AlgorithmName, AVAILABLE_ALGORITHMS, AVAILABLE_MINERS, Miner, MinerInfo, MinerRelease } from '../../models';
 import { AlgorithmMenuItem, MinerTypeMenuItem } from '../components';
 import { CustomDialogActions } from './CustomDialogActions';
 import { aboutApi } from '../../shared/AboutApi';
@@ -61,26 +61,7 @@ export function EditMinerDialog(props: EditMinerDialogProps) {
     }
   });
 
-  const handleOnSave = handleSubmit((val) => {
-    const version = watch('version');
-
-    if (version === '' || minerTypeVersions.includes(version) === false) {
-      onSave({ ...val, id: miner.id, version: minerTypeVersions[0] });
-    } else {
-      onSave({ ...val, id: miner.id, version });
-    }
-
-    if (autoReset) {
-      reset(miner);
-    }
-  });
-
-  const handleOnCancel = () => {
-    reset(miner);
-    onCancel();
-  };
-
-  const pickAlgorithm = (current: string) => {
+  const pickAlgorithm = (current: AlgorithmName) => {
     if (current !== undefined && minerTypeAlgorithms.find((alg) => alg.name === current)) {
       return current;
     }
@@ -94,6 +75,22 @@ export function EditMinerDialog(props: EditMinerDialogProps) {
     }
 
     return current;
+  };
+
+  const handleOnSave = handleSubmit((val) => {
+    const version = pickVersion(watch('version'));
+    const algorithm = pickAlgorithm(watch('algorithm'));
+
+    onSave({ ...val, id: miner.id, version, algorithm });
+
+    if (autoReset) {
+      reset(miner);
+    }
+  });
+
+  const handleOnCancel = () => {
+    reset(miner);
+    onCancel();
   };
 
   const openReference = () => {

--- a/src/renderer/screens/MinersScreen.tsx
+++ b/src/renderer/screens/MinersScreen.tsx
@@ -1,12 +1,13 @@
 import { useState } from 'react';
 import { v4 as uuid } from 'uuid';
 
-import { Container, Box, Button, TableContainer, TableCell, TableHead, TableRow, TableBody, Table } from '@mui/material';
+import { Container, Box, Button, TableContainer, TableCell, TableHead, TableRow, TableBody, Table, Tooltip } from '@mui/material';
 import CheckIcon from '@mui/icons-material/Check';
 import AddIcon from '@mui/icons-material/Add';
+import ErrorIcon from '@mui/icons-material/Error';
 import { useSnackbar } from 'notistack';
 
-import { Miner } from '../../models';
+import { Miner, AVAILABLE_ALGORITHMS } from '../../models';
 import { setMiners, getAppSettings, setAppSettings } from '../services/AppSettingsService';
 
 import { ScreenHeader, EditMinerControls } from '../components';
@@ -14,7 +15,7 @@ import { EditMinerDialog } from '../dialogs/EditMinerDialog';
 import { useLoadData, useProfile } from '../hooks';
 
 const getEmptyMiner = (): Miner => {
-  return { id: uuid(), kind: 'lolminer', name: '', version: '', algorithm: 'ethash', parameters: '' };
+  return { id: uuid(), kind: 'lolminer', name: '', version: '', algorithm: 'etchash', parameters: '' };
 };
 
 export function MinersScreen() {
@@ -57,6 +58,18 @@ export function MinersScreen() {
     enqueueSnackbar(`Miner ${miner.name} added.`, { variant: 'success' });
   };
 
+  const validateMiner = (miner: Miner) => {
+    if (AVAILABLE_ALGORITHMS.find((alg) => alg.name === miner.algorithm) === undefined) {
+      return (
+        <Tooltip title="The configured algorithm is not supported.">
+          <ErrorIcon color="error" />
+        </Tooltip>
+      );
+    }
+
+    return <></>;
+  };
+
   const removeMiner = async (name: string, id: string) => {
     const updatedMiners = [...miners.filter((m) => m.id !== id)];
 
@@ -97,6 +110,7 @@ export function MinersScreen() {
             <TableHead>
               <TableRow>
                 <TableCell />
+                <TableCell />
                 <TableCell>Default</TableCell>
                 <TableCell>Name</TableCell>
                 <TableCell>Miner</TableCell>
@@ -107,6 +121,7 @@ export function MinersScreen() {
             <TableBody>
               {miners.map((m) => (
                 <TableRow key={m.id}>
+                  <TableCell>{validateMiner(m)}</TableCell>
                   <TableCell>
                     <EditMinerControls miner={m} isDefault={profile === m.name} onSave={saveMiner} existingMiners={miners} onRemove={removeMiner} />
                   </TableCell>

--- a/src/renderer/screens/SettingsScreen.tsx
+++ b/src/renderer/screens/SettingsScreen.tsx
@@ -147,19 +147,6 @@ export function SettingsScreen() {
           Connection URLs
         </Typography>
         <Stack direction="column" spacing={DefaultSpacing} sx={{ width: '25rem' }}>
-          <ConfigurableControl description="The URL to use when connecting to a mining pool using the ethash algorithm.">
-            <TextField
-              required
-              spellCheck="false"
-              label="Ethash"
-              fullWidth
-              {...register('pools.ethash', {
-                required: 'A pool url must be specified.',
-              })}
-              error={!!errors?.pools?.ethash}
-              helperText={errors?.pools?.ethash?.message}
-            />
-          </ConfigurableControl>
           <ConfigurableControl description="The URL to use when connecting to a mining pool using the etchash algorithm.">
             <TextField
               required

--- a/src/renderer/services/MinerManager.ts
+++ b/src/renderer/services/MinerManager.ts
@@ -3,7 +3,7 @@ import path from 'path-browserify';
 import * as miningService from './MinerService';
 import * as config from './AppSettingsService';
 import { minerApi } from '../../shared/MinerApi';
-import { ALL_COINS, CoinDefinition, AVAILABLE_MINERS, Miner, Coin, MinerInfo, Wallet, MinerState, minerState$, addAppNotice } from '../../models';
+import { ALL_COINS, CoinDefinition, AVAILABLE_MINERS, AVAILABLE_ALGORITHMS, Miner, Coin, MinerInfo, Wallet, MinerState, minerState$, addAppNotice } from '../../models';
 import { getMiners, getAppSettings, watchers$ as settingsWatcher$ } from './AppSettingsService';
 import { downloadMiner } from './DownloadManager';
 import * as coinStrategy from './strategies';
@@ -109,6 +109,11 @@ async function changeCoin(symbol: string | null) {
       const minerArgs = minerInfo.getArgs(miner.algorithm, cs, appSettings.pools[miner.algorithm]);
       const extraArgs = miner.parameters;
       const mergedArgs = `${minerArgs} ${extraArgs}`;
+
+      if (AVAILABLE_ALGORITHMS.find((alg) => alg.name === miner.algorithm) === undefined) {
+        addAppNotice('error', `Mining using the ${miner.algorithm} algorithm is not supported.`);
+        return;
+      }
 
       console.log(`Selected coin ${coin.symbol} to run for ${coin.duration} hours.  Path: ${filePath} -- Args: ${mergedArgs}`);
 

--- a/src/renderer/services/UnmineableFeed.ts
+++ b/src/renderer/services/UnmineableFeed.ts
@@ -27,7 +27,6 @@ export type AlgorithmStat = {
 };
 
 export type UnmineableStats = {
-  ethash: AlgorithmStat;
   etchash: AlgorithmStat;
   kawpow: AlgorithmStat;
   autolykos: AlgorithmStat;
@@ -79,7 +78,6 @@ function updateWorkers(uuid: string) {
       const raw = JSON.parse(w);
 
       return {
-        ethash: raw.data.ethash,
         etchash: raw.data.etchash,
         kawpow: raw.data.kawpow,
         autolykos: raw.data.autolykos,
@@ -149,7 +147,6 @@ minerState$.pipe(filter((s) => s.state === 'active')).subscribe(() => {
   };
 
   unmineableWorkers$.next({
-    ethash: blankStat(),
     etchash: blankStat(),
     kawpow: blankStat(),
     autolykos: blankStat(),


### PR DESCRIPTION
Removed all support for mining using the ethash algorithm.

* `ethash` is no longer a selectable algorithm when configuring miners.
* The miners screen will now display an error next to any configured miner that does not use a supported algorithm (e.g. `ethash`).
* Attempting to start mining using a miner that is misconfigured will immediately error our and give the user a message notifying them that they need to fix their configuration.
* `ethash` graphs on the home page have been removed.
* The `ethash` pool in general settings has been removed and is no longer configurable.

Note: While `ethash` is no longer a configurable algorithm it is **NOT** removed from the configuration schema.  This was a deliberate decision to prevent existing users' configurations from breaking when upgrading to this version of the app.