### PR TITLE
Added support for CPU mining

### DIFF
--- a/src/__tests__/data/xmrig_backends.txt
+++ b/src/__tests__/data/xmrig_backends.txt
@@ -1,0 +1,103 @@
+[
+    {
+        "type": "cpu",
+        "enabled": true,
+        "algo": "ghostrider",
+        "profile": "ghostrider",
+        "hw-aes": true,
+        "priority": -1,
+        "msr": true,
+        "asm": "ryzen",
+        "argon2-impl": null,
+        "hugepages": [96, 96],
+        "memory": 201326592,
+        "hashrate": [3065.79, 3031.67, 3309.3],
+        "threads": [
+            {
+                "intensity": 8,
+                "affinity": 0,
+                "av": 10,
+                "hashrate": [286.87, 276.27, 301.47]
+            },
+            {
+                "intensity": 8,
+                "affinity": 2,
+                "av": 10,
+                "hashrate": [323.45, 317.28, 332.19]
+            },
+            {
+                "intensity": 8,
+                "affinity": 4,
+                "av": 10,
+                "hashrate": [219.51, 216.18, 245.55]
+            },
+            {
+                "intensity": 8,
+                "affinity": 6,
+                "av": 10,
+                "hashrate": [231.16, 231.77, 255.63]
+            },
+            {
+                "intensity": 8,
+                "affinity": 8,
+                "av": 10,
+                "hashrate": [224.5, 223.17, 247.39]
+            },
+            {
+                "intensity": 8,
+                "affinity": 10,
+                "av": 10,
+                "hashrate": [233.65, 234.46, 257.13]
+            },
+            {
+                "intensity": 8,
+                "affinity": 12,
+                "av": 10,
+                "hashrate": [298.51, 292.81, 319.73]
+            },
+            {
+                "intensity": 8,
+                "affinity": 14,
+                "av": 10,
+                "hashrate": [330.11, 328.03, 345.28]
+            },
+            {
+                "intensity": 8,
+                "affinity": 16,
+                "av": 10,
+                "hashrate": [236.98, 236.34, 258.95]
+            },
+            {
+                "intensity": 8,
+                "affinity": 18,
+                "av": 10,
+                "hashrate": [222.84, 221.42, 242.7]
+            },
+            {
+                "intensity": 8,
+                "affinity": 20,
+                "av": 10,
+                "hashrate": [226.17, 222.77, 248.05]
+            },
+            {
+                "intensity": 8,
+                "affinity": 22,
+                "av": 10,
+                "hashrate": [231.99, 231.1, 255.18]
+            }
+        ]
+    },
+    {
+        "type": "opencl",
+        "enabled": false,
+        "algo": null,
+        "profile": null,
+        "platform": null
+    },
+    {
+        "type": "cuda",
+        "enabled": false,
+        "algo": null,
+        "profile": null
+    }
+]

--- a/src/__tests__/data/xmrig_summary.txt
+++ b/src/__tests__/data/xmrig_summary.txt
@@ -1,0 +1,76 @@
+{
+    "id": "d1559370de02ac02",
+    "worker_id": "bawxy",
+    "uptime": 193266,
+    "restricted": true,
+    "resources": {
+        "memory": {
+            "free": 18452905984,
+            "total": 34281111552,
+            "resident_set_memory": 22007808
+        },
+        "load_average": [0.0, 0.0, 0.0],
+        "hardware_concurrency": 24
+    },
+    "features": ["api", "asm", "http", "hwloc", "tls", "opencl", "cuda"],
+    "results": {
+        "diff_current": 52514,
+        "shares_good": 22869,
+        "shares_total": 22903,
+        "avg_time": 8,
+        "avg_time_ms": 8451,
+        "hashes_total": 715537000,
+        "best": [627884623, 488830556, 345229984, 291478788, 221671965, 177458774, 160687832, 105090210, 82054552, 79269599]
+    },
+    "algo": "ghostrider",
+    "connection": {
+        "pool": "stratum.us-ny1.suprnova.cc:6273",
+        "ip": "66.165.247.2",
+        "uptime": 193266,
+        "uptime_ms": 193266224,
+        "ping": 104,
+        "failures": 0,
+        "tls": null,
+        "tls-fingerprint": null,
+        "algo": "ghostrider",
+        "diff": 52514,
+        "accepted": 22869,
+        "rejected": 34,
+        "avg_time": 8,
+        "avg_time_ms": 8451,
+        "hashes_total": 715537000
+    },
+    "version": "6.18.0",
+    "kind": "miner",
+    "ua": "XMRig/6.18.0 (Windows NT 10.0; Win64; x64) libuv/1.44.1 msvc/2019",
+    "cpu": {
+        "brand": "AMD Ryzen 9 5900X 12-Core Processor",
+        "family": 25,
+        "model": 33,
+        "stepping": 0,
+        "proc_info": 10620688,
+        "aes": true,
+        "avx2": true,
+        "x64": true,
+        "64_bit": true,
+        "l2": 6291456,
+        "l3": 67108864,
+        "cores": 12,
+        "threads": 24,
+        "packages": 1,
+        "nodes": 1,
+        "backend": "hwloc/2.7.1",
+        "msr": "ryzen_19h",
+        "assembly": "ryzen",
+        "arch": "x86_64",
+        "flags": ["aes", "vaes", "avx", "avx2", "bmi2", "osxsave", "pdpe1gb", "sse2", "ssse3", "sse4.1", "popcnt", "vm"]
+    },
+    "donate_level": 1,
+    "paused": false,
+    "algorithms": ["cn/1", "cn/2", "cn/r", "cn/fast", "cn/half", "cn/xao", "cn/rto", "cn/rwz", "cn/zls", "cn/double", "cn/ccx", "cn-lite/1", "cn-heavy/0", "cn-heavy/tube", "cn-heavy/xhv", "cn-pico", "cn-pico/tlo", "cn/upx2", "rx/0", "rx/wow", "rx/arq", "rx/graft", "rx/sfx", "rx/keva", "argon2/chukwa", "argon2/chukwav2", "argon2/ninja", "ghostrider"],
+    "hashrate": {
+        "total": [3026.89, 2932.32, 3586.31],
+        "highest": 12327.59
+    },
+    "hugepages": [96, 96]
+}

--- a/src/__tests__/services/Formatters.tests.ts
+++ b/src/__tests__/services/Formatters.tests.ts
@@ -1,6 +1,47 @@
 import * as formatter from '../../renderer/services/Formatters';
 
 describe('Formatters Service', () => {
+  describe('Hashrate For Empty Values', () => {
+    const cases = [
+      null,
+      undefined,
+    ];
+
+    test.each(cases)('%p', (given) => {
+      // Act.
+      const result = formatter.hashrate(given);
+
+      // Assert.
+      expect(result).toBe('N/A');
+    });
+  });
+
+  describe('Hashrate Formatting', () => {
+    it('Should return raw number if no scale provided.', () => {
+      // Act.
+      const result = formatter.hashrate(10);
+
+      // Assert.
+      expect(result).toBe('10');
+    });
+
+    it('Should return unaltered suffix for M', () => {
+      // Act.
+      const result = formatter.hashrate(10, 'M');
+
+      // Assert.
+      expect(result).toBe('10MH/s');
+    });
+
+    it('Should return scaled number scaled by 1000 for K', () => {
+      // Act.
+      const result = formatter.hashrate(1000, 'K');
+
+      // Assert.
+      expect(result).toBe('1KH/s');
+    });
+  });
+
   describe('Uptime', () => {
     const cases = [
       { expected: 'N/A' },

--- a/src/models/Aggregates.ts
+++ b/src/models/Aggregates.ts
@@ -14,6 +14,22 @@ export type GpuStatistic = {
   fanSpeed?: number;
 };
 
+export type CpuStatistic = {
+  hashrate?: number;
+  accepted?: number;
+  rejected?: number;
+  cores?: number;
+  threads?: number;
+  algorithm?: string;
+  difficulty?: number;
+  uptime?: number;
+  timings?: {
+    tenSeconds: number;
+    sixtySeconds: number;
+    fifteenMinutes: number;
+  }[],
+};
+
 export type MinerStatistic = {
   hashrate?: number;
   accepted?: number;

--- a/src/models/Enums.ts
+++ b/src/models/Enums.ts
@@ -1,5 +1,4 @@
-export const GPU_API_PORT = 60090;
-export const CPU_API_PORT = 60080;
+export const API_PORT = 60090;
 
 export type MinerName = 'phoenixminer' | 'lolminer' | 'nbminer' | 'trexminer' | 'xmrig';
 export type AlgorithmKind = 'CPU' | 'GPU';

--- a/src/models/Enums.ts
+++ b/src/models/Enums.ts
@@ -1,4 +1,5 @@
-export const API_PORT = 60090;
+export const GPU_API_PORT = 60090;
+export const CPU_API_PORT = 60080;
 
 export type MinerName = 'phoenixminer' | 'lolminer' | 'nbminer' | 'trexminer' | 'xmrig';
 export type AlgorithmKind = 'CPU' | 'GPU';

--- a/src/models/MinerInfo.ts
+++ b/src/models/MinerInfo.ts
@@ -1,4 +1,4 @@
-import { MinerName, AlgorithmName, GPU_API_PORT, CPU_API_PORT } from './Enums';
+import { MinerName, AlgorithmName, API_PORT } from './Enums';
 
 export type MinerInfo = {
   name: MinerName;
@@ -28,7 +28,7 @@ export const AVAILABLE_MINERS: MinerInfo[] = [
     assetPattern: /^.+Win64\.zip$/,
     optionsUrl: 'https://lolminer.site/documentation/arguments/',
     exe: 'lolminer.exe',
-    getArgs: (alg, cs, url) => `--algo ${alg.toLocaleUpperCase()} --pool ${url} --user ${cs} --nocolor --apiport ${GPU_API_PORT}`,
+    getArgs: (alg, cs, url) => `--algo ${alg.toLocaleUpperCase()} --pool ${url} --user ${cs} --nocolor --apiport ${API_PORT}`,
   },
   {
     name: 'nbminer',
@@ -38,7 +38,7 @@ export const AVAILABLE_MINERS: MinerInfo[] = [
     assetPattern: /^NBMiner.+_Win\.zip$/,
     optionsUrl: 'https://nbminer.info/documentation/arguments/',
     exe: 'nbminer.exe',
-    getArgs: (alg, cs, url) => `-a ${alg} -o stratum+tcp://${url} -u ${cs} --no-color --cmd-output 1 --api 127.0.0.1:${GPU_API_PORT}`,
+    getArgs: (alg, cs, url) => `-a ${alg} -o stratum+tcp://${url} -u ${cs} --no-color --cmd-output 1 --api 127.0.0.1:${API_PORT}`,
   },
   {
     name: 'trexminer',
@@ -48,7 +48,7 @@ export const AVAILABLE_MINERS: MinerInfo[] = [
     assetPattern: /^t-rex-.+win.zip$/,
     optionsUrl: 'https://trexminer.info/documentation/arguments/',
     exe: 't-rex.exe',
-    getArgs: (alg, cs, url) => `-a ${alg} -o ${url} -u ${cs} -p x --api-bind-http 127.0.0.1:${GPU_API_PORT} --api-read-only --no-color`,
+    getArgs: (alg, cs, url) => `-a ${alg} -o ${url} -u ${cs} -p x --api-bind-http 127.0.0.1:${API_PORT} --api-read-only --no-color`,
   },
   {
     name: 'xmrig',
@@ -58,6 +58,6 @@ export const AVAILABLE_MINERS: MinerInfo[] = [
     assetPattern: /^xmrig.+win64\.zip$/,
     optionsUrl: 'https://xmrig.com/docs/miner/command-line-options',
     exe: 'xmrig.exe',
-    getArgs: (_alg, cs, url) => `-o ${url} -a rx -k -u ${cs} -p x --http-host=127.0.0.1 --http-port=${CPU_API_PORT}`,
+    getArgs: (_alg, cs, url) => `-o ${url} -a rx -k -u ${cs} -p x --http-host=127.0.0.1 --http-port=${API_PORT}`,
   },
 ];

--- a/src/models/MinerInfo.ts
+++ b/src/models/MinerInfo.ts
@@ -1,4 +1,4 @@
-import { MinerName, AlgorithmName, API_PORT } from './Enums';
+import { MinerName, AlgorithmName, GPU_API_PORT, CPU_API_PORT } from './Enums';
 
 export type MinerInfo = {
   name: MinerName;
@@ -28,7 +28,7 @@ export const AVAILABLE_MINERS: MinerInfo[] = [
     assetPattern: /^.+Win64\.zip$/,
     optionsUrl: 'https://lolminer.site/documentation/arguments/',
     exe: 'lolminer.exe',
-    getArgs: (alg, cs, url) => `--algo ${alg.toLocaleUpperCase()} --pool ${url} --user ${cs} --nocolor --apiport ${API_PORT}`,
+    getArgs: (alg, cs, url) => `--algo ${alg.toLocaleUpperCase()} --pool ${url} --user ${cs} --nocolor --apiport ${GPU_API_PORT}`,
   },
   {
     name: 'nbminer',
@@ -38,7 +38,7 @@ export const AVAILABLE_MINERS: MinerInfo[] = [
     assetPattern: /^NBMiner.+_Win\.zip$/,
     optionsUrl: 'https://nbminer.info/documentation/arguments/',
     exe: 'nbminer.exe',
-    getArgs: (alg, cs, url) => `-a ${alg} -o stratum+tcp://${url} -u ${cs} --no-color --cmd-output 1 --api 127.0.0.1:60090`,
+    getArgs: (alg, cs, url) => `-a ${alg} -o stratum+tcp://${url} -u ${cs} --no-color --cmd-output 1 --api 127.0.0.1:${GPU_API_PORT}`,
   },
   {
     name: 'trexminer',
@@ -48,14 +48,16 @@ export const AVAILABLE_MINERS: MinerInfo[] = [
     assetPattern: /^t-rex-.+win.zip$/,
     optionsUrl: 'https://trexminer.info/documentation/arguments/',
     exe: 't-rex.exe',
-    getArgs: (alg, cs, url) => `-a ${alg} -o ${url} -u ${cs} -p x --api-bind-http 127.0.0.1:60090 --api-read-only --no-color`,
+    getArgs: (alg, cs, url) => `-a ${alg} -o ${url} -u ${cs} -p x --api-bind-http 127.0.0.1:${GPU_API_PORT} --api-read-only --no-color`,
   },
-  // {
-  //   name: 'xmrig',
-  //   algorithms: ['randomx'],
-  //   owner: 'xmrig',
-  //   repo: 'xmrig',
-  //   exe: 'xmrig.exe',
-  //   getArgs: (_alg, cs, url) => `o ${url} -a rx -k -u ${cs} -p x`,
-  // },
+  {
+    name: 'xmrig',
+    algorithms: ['randomx'],
+    owner: 'xmrig',
+    repo: 'xmrig',
+    assetPattern: /^xmrig.+win64\.zip$/,
+    optionsUrl: 'https://xmrig.com/docs/miner/command-line-options',
+    exe: 'xmrig.exe',
+    getArgs: (_alg, cs, url) => `-o ${url} -a rx -k -u ${cs} -p x --http-host=127.0.0.1 --http-port=${CPU_API_PORT}`,
+  },
 ];

--- a/src/models/MinerState.ts
+++ b/src/models/MinerState.ts
@@ -1,8 +1,10 @@
 import { MinerName } from './Enums';
+import { AlgorithmInfo } from './AlgorithmInfo';
 
 export type MinerState = {
   state: 'active' | 'inactive';
   currentCoin: string | null;
+  algorithm?: AlgorithmInfo;
   profile?: string;
   miner?: MinerName;
 };

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -8,7 +8,7 @@ export { AlgorithmInfo, AVAILABLE_ALGORITHMS } from './AlgorithmInfo';
 export { GeneralSettings, AppSettings } from './AppSettings';
 export { Miner } from './Miner';
 export { MinerInfo, AVAILABLE_MINERS } from './MinerInfo';
-export { GpuStatistic, MinerStatistic } from './Aggregates';
+export { CpuStatistic, GpuStatistic, MinerStatistic } from './Aggregates';
 export { ConfiguredCoin } from './ConfiguredCoin';
 export { MinerState } from './MinerState';
 export { appNotice$, minerState$, enabledCoins$, refreshData$, addAppNotice } from './Observables';

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -3,7 +3,7 @@ export { CoinDefinition, ALL_COINS } from './CoinDefinition';
 export { CoinSelection } from './CoinSelection';
 export { Wallet } from './Wallet';
 export { Coin } from './Coin';
-export { AlgorithmName, AlgorithmKind, MinerName, CoinSelectionStrategy, GPU_API_PORT, CPU_API_PORT } from './Enums';
+export { AlgorithmName, AlgorithmKind, MinerName, CoinSelectionStrategy, API_PORT } from './Enums';
 export { AlgorithmInfo, AVAILABLE_ALGORITHMS } from './AlgorithmInfo';
 export { GeneralSettings, AppSettings } from './AppSettings';
 export { Miner } from './Miner';

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -3,7 +3,7 @@ export { CoinDefinition, ALL_COINS } from './CoinDefinition';
 export { CoinSelection } from './CoinSelection';
 export { Wallet } from './Wallet';
 export { Coin } from './Coin';
-export { AlgorithmName, AlgorithmKind, MinerName, CoinSelectionStrategy, API_PORT } from './Enums';
+export { AlgorithmName, AlgorithmKind, MinerName, CoinSelectionStrategy, GPU_API_PORT, CPU_API_PORT } from './Enums';
 export { AlgorithmInfo, AVAILABLE_ALGORITHMS } from './AlgorithmInfo';
 export { GeneralSettings, AppSettings } from './AppSettings';
 export { Miner } from './Miner';

--- a/src/renderer/components/dashboard/CpuComputeTable.tsx
+++ b/src/renderer/components/dashboard/CpuComputeTable.tsx
@@ -1,4 +1,4 @@
-import { Table, TableContainer, TableCell, TableHead, TableRow, TableBody, Typography } from '@mui/material';
+import { Table, TableContainer, TableHead, TableRow, TableBody, Typography } from '@mui/material';
 // import * as formatter from '../../services/Formatters';
 import { gpuStatistics$ } from '../../services/StatisticsAggregator';
 import { useObservableState } from '../../hooks';

--- a/src/renderer/components/dashboard/CpuComputeTable.tsx
+++ b/src/renderer/components/dashboard/CpuComputeTable.tsx
@@ -1,12 +1,12 @@
-import { Table, TableContainer, TableHead, TableRow, TableBody, Typography } from '@mui/material';
-// import * as formatter from '../../services/Formatters';
-import { gpuStatistics$ } from '../../services/StatisticsAggregator';
+import { Table, TableContainer, TableHead, TableCell, TableRow, TableBody, Typography } from '@mui/material';
+import * as formatter from '../../services/Formatters';
+import { cpuStatistics$ } from '../../services/StatisticsAggregator';
 import { useObservableState } from '../../hooks';
 
 export function CpuComputeTable() {
-  const [gpus] = useObservableState(gpuStatistics$, []);
+  const [cpu] = useObservableState(cpuStatistics$, null);
 
-  if (gpus.length === 0) {
+  if (cpu === null || !cpu.timings) {
     return <Typography>No data to display!</Typography>;
   }
 
@@ -14,12 +14,26 @@ export function CpuComputeTable() {
     <TableContainer>
       <Table>
         <TableHead>
-          <TableRow />
+          <TableRow>
+            <TableCell>Hashrate</TableCell>
+            {cpu.timings.map((_t, index) => (
+              <TableCell>{index}</TableCell>
+            ))}
+          </TableRow>
         </TableHead>
         <TableBody>
-          {gpus.map((gpu) => (
-            <TableRow key={gpu.id} />
-          ))}
+          <TableRow>
+            <TableCell>10s</TableCell>
+            {cpu.timings.map((t) => <TableCell>{formatter.hashrate(t.tenSeconds)}</TableCell>)}
+          </TableRow>
+          <TableRow>
+            <TableCell>60s</TableCell>
+            {cpu.timings.map((t) => <TableCell>{formatter.hashrate(t.sixtySeconds)}</TableCell>)}
+          </TableRow>
+          <TableRow>
+            <TableCell>15m</TableCell>
+            {cpu.timings.map((t) => <TableCell>{formatter.hashrate(t.fifteenMinutes)}</TableCell>)}
+          </TableRow>
         </TableBody>
       </Table>
     </TableContainer>

--- a/src/renderer/components/dashboard/CpuComputeTable.tsx
+++ b/src/renderer/components/dashboard/CpuComputeTable.tsx
@@ -1,0 +1,27 @@
+import { Table, TableContainer, TableCell, TableHead, TableRow, TableBody, Typography } from '@mui/material';
+// import * as formatter from '../../services/Formatters';
+import { gpuStatistics$ } from '../../services/StatisticsAggregator';
+import { useObservableState } from '../../hooks';
+
+export function CpuComputeTable() {
+  const [gpus] = useObservableState(gpuStatistics$, []);
+
+  if (gpus.length === 0) {
+    return <Typography>No data to display!</Typography>;
+  }
+
+  return (
+    <TableContainer>
+      <Table>
+        <TableHead>
+          <TableRow />
+        </TableHead>
+        <TableBody>
+          {gpus.map((gpu) => (
+            <TableRow key={gpu.id} />
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}

--- a/src/renderer/components/dashboard/CpuSummaryTable.tsx
+++ b/src/renderer/components/dashboard/CpuSummaryTable.tsx
@@ -5,7 +5,6 @@ import { useObservableState } from '../../hooks';
 
 export function CpuSummaryTable() {
   const [cpu] = useObservableState(cpuStatistics$, null);
-  // const { hashrate, accepted, rejected, power, efficiency, difficulty, uptime } = miner ?? {};
   const { hashrate, accepted, rejected, cores, threads, algorithm, difficulty, uptime } = cpu ?? { };
 
   if (cpu === null || Object.values(cpu).find((x) => x !== undefined) === undefined) {

--- a/src/renderer/components/dashboard/CpuSummaryTable.tsx
+++ b/src/renderer/components/dashboard/CpuSummaryTable.tsx
@@ -1,13 +1,14 @@
 import { Table, TableContainer, TableCell, TableHead, TableRow, TableBody, Typography } from '@mui/material';
-// import * as formatter from '../../services/Formatters';
-import { minerStatistics$ } from '../../services/StatisticsAggregator';
+import * as formatter from '../../services/Formatters';
+import { cpuStatistics$ } from '../../services/StatisticsAggregator';
 import { useObservableState } from '../../hooks';
 
 export function CpuSummaryTable() {
-  const [miner] = useObservableState(minerStatistics$, null);
+  const [cpu] = useObservableState(cpuStatistics$, null);
   // const { hashrate, accepted, rejected, power, efficiency, difficulty, uptime } = miner ?? {};
+  const { hashrate, accepted, rejected, cores, threads, algorithm, difficulty, uptime } = cpu ?? { };
 
-  if (miner === null || Object.values(miner).find((x) => x !== undefined) === undefined) {
+  if (cpu === null || Object.values(cpu).find((x) => x !== undefined) === undefined) {
     return <Typography>No data to display!</Typography>;
   }
 
@@ -16,7 +17,7 @@ export function CpuSummaryTable() {
       <Table>
         <TableHead>
           <TableRow>
-            <TableCell>Hashrate</TableCell>
+            <TableCell>Hashrate (10s)</TableCell>
             <TableCell>Accepted</TableCell>
             <TableCell>Rejected</TableCell>
             <TableCell>Cores</TableCell>
@@ -27,7 +28,16 @@ export function CpuSummaryTable() {
           </TableRow>
         </TableHead>
         <TableBody>
-          <TableRow />
+          <TableRow>
+            <TableCell>{formatter.hashrate(hashrate, 'K')}</TableCell>
+            <TableCell>{formatter.number(accepted)}</TableCell>
+            <TableCell>{formatter.number(rejected)}</TableCell>
+            <TableCell>{formatter.number(cores)}</TableCell>
+            <TableCell>{formatter.number(threads)}</TableCell>
+            <TableCell>{algorithm}</TableCell>
+            <TableCell>{formatter.number(difficulty)}</TableCell>
+            <TableCell>{formatter.uptime(uptime)}</TableCell>
+          </TableRow>
         </TableBody>
       </Table>
     </TableContainer>

--- a/src/renderer/components/dashboard/CpuSummaryTable.tsx
+++ b/src/renderer/components/dashboard/CpuSummaryTable.tsx
@@ -1,0 +1,35 @@
+import { Table, TableContainer, TableCell, TableHead, TableRow, TableBody, Typography } from '@mui/material';
+// import * as formatter from '../../services/Formatters';
+import { minerStatistics$ } from '../../services/StatisticsAggregator';
+import { useObservableState } from '../../hooks';
+
+export function CpuSummaryTable() {
+  const [miner] = useObservableState(minerStatistics$, null);
+  // const { hashrate, accepted, rejected, power, efficiency, difficulty, uptime } = miner ?? {};
+
+  if (miner === null || Object.values(miner).find((x) => x !== undefined) === undefined) {
+    return <Typography>No data to display!</Typography>;
+  }
+
+  return (
+    <TableContainer>
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell>Hashrate</TableCell>
+            <TableCell>Accepted</TableCell>
+            <TableCell>Rejected</TableCell>
+            <TableCell>Cores</TableCell>
+            <TableCell>Threads</TableCell>
+            <TableCell>Algorithm</TableCell>
+            <TableCell>Difficulty</TableCell>
+            <TableCell>Uptime</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          <TableRow />
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}

--- a/src/renderer/components/dashboard/GpuComputeTable.tsx
+++ b/src/renderer/components/dashboard/GpuComputeTable.tsx
@@ -3,7 +3,7 @@ import * as formatter from '../../services/Formatters';
 import { gpuStatistics$ } from '../../services/StatisticsAggregator';
 import { useObservableState } from '../../hooks';
 
-export function ComputeTable() {
+export function GpuComputeTable() {
   const [gpus] = useObservableState(gpuStatistics$, []);
 
   if (gpus.length === 0) {

--- a/src/renderer/components/dashboard/GpuComputeTable.tsx
+++ b/src/renderer/components/dashboard/GpuComputeTable.tsx
@@ -33,7 +33,7 @@ export function GpuComputeTable() {
             <TableRow key={gpu.id}>
               <TableCell>{gpu.id}</TableCell>
               <TableCell>{gpu.name}</TableCell>
-              <TableCell>{formatter.hashrate(gpu.hashrate)}</TableCell>
+              <TableCell>{formatter.hashrate(gpu.hashrate, 'M')}</TableCell>
               <TableCell>{formatter.shares(gpu.accepted, gpu.rejected)}</TableCell>
               <TableCell>{formatter.power(gpu.power)}</TableCell>
               <TableCell>{formatter.efficiency(gpu.efficiency)}</TableCell>

--- a/src/renderer/components/dashboard/GpuSummaryTable.tsx
+++ b/src/renderer/components/dashboard/GpuSummaryTable.tsx
@@ -3,7 +3,7 @@ import * as formatter from '../../services/Formatters';
 import { minerStatistics$ } from '../../services/StatisticsAggregator';
 import { useObservableState } from '../../hooks';
 
-export function MinerTable() {
+export function GpuSummaryTable() {
   const [miner] = useObservableState(minerStatistics$, null);
   const { hashrate, accepted, rejected, power, efficiency, difficulty, uptime } = miner ?? {};
 

--- a/src/renderer/components/dashboard/GpuSummaryTable.tsx
+++ b/src/renderer/components/dashboard/GpuSummaryTable.tsx
@@ -27,7 +27,7 @@ export function GpuSummaryTable() {
         </TableHead>
         <TableBody>
           <TableRow>
-            <TableCell>{formatter.hashrate(hashrate)}</TableCell>
+            <TableCell>{formatter.hashrate(hashrate, 'M')}</TableCell>
             <TableCell>{formatter.found(accepted, rejected)}</TableCell>
             <TableCell>{formatter.shares(accepted, rejected)}</TableCell>
             <TableCell>{formatter.power(power)}</TableCell>

--- a/src/renderer/components/dashboard/WorkersGraphs.tsx
+++ b/src/renderer/components/dashboard/WorkersGraphs.tsx
@@ -19,8 +19,8 @@ function shrink<T>(items: T[]) {
   return result;
 }
 
-function WorkersGraph(props: { algorithm: string; stat: AlgorithmStat | undefined }) {
-  const { algorithm, stat } = props;
+function WorkersGraph(props: { algorithm: string; stat: AlgorithmStat | undefined, scale: string; }) {
+  const { algorithm, stat, scale } = props;
 
   if (stat === undefined || stat.workers === undefined || stat.chart === undefined) {
     return <Typography>No data to display!</Typography>;
@@ -47,7 +47,7 @@ function WorkersGraph(props: { algorithm: string; stat: AlgorithmStat | undefine
       y: {
         title: {
           display: true,
-          text: 'Hashrate (MH/s)',
+          text: `Hashrate ${scale}`,
         },
       },
     },
@@ -110,16 +110,16 @@ export function WorkersGraphs() {
       </Tabs>
 
       <TabPanel value={tabIndex} index={0}>
-        <WorkersGraph algorithm="Etchash" stat={workers?.etchash} />
+        <WorkersGraph algorithm="Etchash" stat={workers?.etchash} scale="MH/s" />
       </TabPanel>
       <TabPanel value={tabIndex} index={1}>
-        <WorkersGraph algorithm="Kawpow" stat={workers?.kawpow} />
+        <WorkersGraph algorithm="Kawpow" stat={workers?.kawpow} scale="MH/s" />
       </TabPanel>
       <TabPanel value={tabIndex} index={2}>
-        <WorkersGraph algorithm="Autolykos" stat={workers?.autolykos} />
+        <WorkersGraph algorithm="Autolykos" stat={workers?.autolykos} scale="MH/s" />
       </TabPanel>
       <TabPanel value={tabIndex} index={3}>
-        <WorkersGraph algorithm="RandomX" stat={workers?.randomx} />
+        <WorkersGraph algorithm="RandomX" stat={workers?.randomx} scale="H/s" />
       </TabPanel>
     </div>
   );

--- a/src/renderer/components/dashboard/index.ts
+++ b/src/renderer/components/dashboard/index.ts
@@ -1,4 +1,5 @@
-export { ComputeTable } from './ComputeTable';
+export { CpuComputeTable } from './CpuComputeTable';
+export { GpuComputeTable } from './GpuComputeTable';
 export { MinerTable } from './MinerTable';
 export { CoinsTable } from './CoinsTable';
 export { WorkersGraphs } from './WorkersGraphs';

--- a/src/renderer/components/dashboard/index.ts
+++ b/src/renderer/components/dashboard/index.ts
@@ -1,5 +1,6 @@
 export { CpuComputeTable } from './CpuComputeTable';
+export { CpuSummaryTable } from './CpuSummaryTable';
 export { GpuComputeTable } from './GpuComputeTable';
-export { MinerTable } from './MinerTable';
+export { GpuSummaryTable } from './GpuSummaryTable';
 export { CoinsTable } from './CoinsTable';
 export { WorkersGraphs } from './WorkersGraphs';

--- a/src/renderer/components/toolbars/MinerSummary.tsx
+++ b/src/renderer/components/toolbars/MinerSummary.tsx
@@ -4,16 +4,16 @@ import { Separator } from '../Separator';
 import { useObservableState, useMinerActive } from '../../hooks';
 import { minerState$ } from '../../../models';
 import * as formatter from '../../services/Formatters';
-import { minerStatistics$ } from '../../services/StatisticsAggregator';
+import { currentHashrate$ } from '../../services/StatisticsAggregator';
 
 export function MinerSummary() {
   const [minerState] = useObservableState(minerState$, null);
-  const [minerStatistic] = useObservableState(minerStatistics$, null);
+  const [currentHashrate] = useObservableState(currentHashrate$, null);
   const minerActive = useMinerActive();
 
   const items = [
     { title: 'Coin', content: minerState?.currentCoin },
-    { title: 'Hashrate', content: formatter.hashrate(minerStatistic?.hashrate) },
+    { title: 'Hashrate', content: formatter.hashrate(currentHashrate?.hashrate, currentHashrate?.scale) },
   ];
 
   return (

--- a/src/renderer/screens/HomeScreen.tsx
+++ b/src/renderer/screens/HomeScreen.tsx
@@ -15,7 +15,7 @@ import { useProfile, useMinerActive } from '../hooks';
 
 // Screens.
 import { ScreenHeader } from '../components';
-import { CoinsTable, ComputeTable, MinerTable, WorkersGraphs } from '../components/dashboard';
+import { CoinsTable, CpuComputeTable, GpuComputeTable, MinerTable, WorkersGraphs } from '../components/dashboard';
 
 export function HomeScreen(): JSX.Element {
   const profile = useProfile();
@@ -27,12 +27,16 @@ export function HomeScreen(): JSX.Element {
       component: <CoinsTable />,
     },
     {
-      header: 'GPUs',
-      component: <ComputeTable />,
-    },
-    {
       header: 'General',
       component: <MinerTable />,
+    },
+    {
+      header: 'CPUs',
+      component: <CpuComputeTable />,
+    },
+    {
+      header: 'GPUs',
+      component: <GpuComputeTable />,
     },
     {
       header: 'Graphs',

--- a/src/renderer/screens/HomeScreen.tsx
+++ b/src/renderer/screens/HomeScreen.tsx
@@ -15,7 +15,7 @@ import { useProfile, useMinerActive, useObservableState } from '../hooks';
 
 // Screens.
 import { ScreenHeader } from '../components';
-import { CoinsTable, CpuComputeTable, GpuComputeTable, MinerTable, WorkersGraphs } from '../components/dashboard';
+import { CoinsTable, CpuComputeTable, CpuSummaryTable, GpuComputeTable, GpuSummaryTable, WorkersGraphs } from '../components/dashboard';
 
 export function HomeScreen(): JSX.Element {
   const profile = useProfile();
@@ -29,9 +29,14 @@ export function HomeScreen(): JSX.Element {
       show: () => true,
     },
     {
-      header: 'General',
-      component: <MinerTable />,
-      show: () => true,
+      header: 'Summary',
+      component: <GpuSummaryTable />,
+      show: () => minerState?.algorithm?.kind === 'GPU',
+    },
+    {
+      header: 'Summary',
+      component: <CpuSummaryTable />,
+      show: () => minerState?.algorithm?.kind === 'CPU',
     },
     {
       header: 'CPUs',

--- a/src/renderer/screens/HomeScreen.tsx
+++ b/src/renderer/screens/HomeScreen.tsx
@@ -7,11 +7,11 @@ import NextIcon from '@mui/icons-material/FastForward';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 
 // Services.
-import { refreshData$ } from '../../models';
+import { minerState$, refreshData$ } from '../../models';
 import { startMiner, stopMiner, nextCoin } from '../services/MinerManager';
 
 // Hooks.
-import { useProfile, useMinerActive } from '../hooks';
+import { useProfile, useMinerActive, useObservableState } from '../hooks';
 
 // Screens.
 import { ScreenHeader } from '../components';
@@ -20,27 +20,33 @@ import { CoinsTable, CpuComputeTable, GpuComputeTable, MinerTable, WorkersGraphs
 export function HomeScreen(): JSX.Element {
   const profile = useProfile();
   const minerActive = useMinerActive();
+  const [minerState] = useObservableState(minerState$, null);
 
   const dashboards = [
     {
       header: 'Coins',
       component: <CoinsTable />,
+      show: () => true,
     },
     {
       header: 'General',
       component: <MinerTable />,
+      show: () => true,
     },
     {
       header: 'CPUs',
       component: <CpuComputeTable />,
+      show: () => minerState?.algorithm?.kind === 'CPU',
     },
     {
       header: 'GPUs',
       component: <GpuComputeTable />,
+      show: () => minerState?.algorithm?.kind === 'GPU',
     },
     {
       header: 'Graphs',
       component: <WorkersGraphs />,
+      show: () => true,
     },
   ];
 
@@ -60,7 +66,7 @@ export function HomeScreen(): JSX.Element {
           Refresh
         </Button>
       </ScreenHeader>
-      {dashboards.map((d) => (
+      {dashboards.filter((x) => x.show()).map((d) => (
         <Accordion key={d.header} defaultExpanded>
           <AccordionSummary expandIcon={<ExpandMoreIcon />} aria-controls="panel1a-content" id="panel1a-header">
             <Typography variant="h5">{d.header}</Typography>

--- a/src/renderer/services/Formatters.ts
+++ b/src/renderer/services/Formatters.ts
@@ -17,7 +17,7 @@ export function hashrate(value: number | undefined | null, scale?: 'M' | 'K') {
     return `${number(value / 1000, 2)}KH/s`;
   }
 
-  return number(value);
+  return number(value, 0);
 }
 
 export function shares(accepted: number | undefined, rejected: number | undefined) {

--- a/src/renderer/services/Formatters.ts
+++ b/src/renderer/services/Formatters.ts
@@ -6,8 +6,18 @@ export function currency(value: number | undefined, maxDigits = 2) {
   return value === undefined ? 'N/A' : value.toLocaleString('en-US', { style: 'currency', currency: 'USD', minimumFractionDigits: 2, maximumFractionDigits: maxDigits });
 }
 
-export function hashrate(value: number | undefined) {
-  return value === undefined ? 'N/A' : `${number(value, 2)}MH/s`;
+export function hashrate(value: number | undefined | null, scale?: 'M' | 'K') {
+  if (value === undefined || value === null) {
+    return 'N/A';
+  }
+
+  if (scale === 'M') {
+    return `${number(value, 2)}MH/s`;
+  } if (scale === 'K') {
+    return `${number(value / 1000, 2)}KH/s`;
+  }
+
+  return number(value);
 }
 
 export function shares(accepted: number | undefined, rejected: number | undefined) {

--- a/src/renderer/services/MinerManager.ts
+++ b/src/renderer/services/MinerManager.ts
@@ -29,7 +29,7 @@ function getRandom<T>(array: Array<T>) {
   return array[Math.floor(Math.random() * array.length)];
 }
 
-function lookupAlgorithm(name?: AlgorithmName) {
+function lookupAlgorithm(name: AlgorithmName) {
   return AVAILABLE_ALGORITHMS.find((alg) => alg.name === name);
 }
 
@@ -133,7 +133,12 @@ async function changeCoin(symbol: string | null) {
 
 export async function setProfile(profile: string) {
   const miner = (await getMiners()).find((m) => m.name === profile);
-  updateState({ profile, miner: miner?.kind, algorithm: lookupAlgorithm(miner?.algorithm) });
+
+  if (miner !== undefined) {
+    updateState({ profile, miner: miner.kind, algorithm: lookupAlgorithm(miner.algorithm) });
+  } else {
+    updateState({ profile });
+  }
 }
 
 export async function nextCoin(symbol?: string) {
@@ -170,7 +175,7 @@ async function setInitialState() {
   if (minerState.state === 'active') {
     updateState({ state: 'active', currentCoin: minerState.currentCoin, miner: minerState.miner, profile: minerState.profile, algorithm: minerState.algorithm });
   } else {
-    updateState({ profile: defaultMiner?.name, miner: defaultMiner?.kind, algorithm: lookupAlgorithm(defaultMiner.algorithm) });
+    updateState({ profile: defaultMiner.name, miner: defaultMiner.kind, algorithm: lookupAlgorithm(defaultMiner.algorithm) });
   }
 
   miningService.minerExited$.subscribe(() => {

--- a/src/renderer/services/MonitorService.ts
+++ b/src/renderer/services/MonitorService.ts
@@ -21,19 +21,11 @@ export function enableMonitors() {
       const monitor = monitors.find((m) => m.name === status.miner);
 
       if (monitor) {
-        if (typeof monitor.statsUrl === 'string') {
-          minerApi.stats(API_PORT, monitor.statsUrl).then((result) => {
-            if (result !== '') {
-              monitor.update(result);
-            }
-          });
-        } else {
-          const results = await Promise.allSettled(monitor.statsUrl.map(async (url) => minerApi.stats(API_PORT, url)));
-          // eslint-disable-next-line @typescript-eslint/no-shadow
-          const stats = results.filter(({ status }) => status === 'fulfilled').map((p) => (p as PromiseFulfilledResult<string>).value);
+        const results = await Promise.allSettled(monitor.statsUrls.map(async (url) => minerApi.stats(API_PORT, url)));
+        // eslint-disable-next-line @typescript-eslint/no-shadow
+        const stats = results.filter(({ status }) => status === 'fulfilled').map((p) => (p as PromiseFulfilledResult<string>).value);
 
-          monitor.update(stats);
-        }
+        monitor.update(stats);
       }
     });
 

--- a/src/renderer/services/MonitorService.ts
+++ b/src/renderer/services/MonitorService.ts
@@ -1,13 +1,13 @@
 import { interval, withLatestFrom, map, filter } from 'rxjs';
 import { minerState$, API_PORT } from '../../models';
 import { minerApi } from '../../shared/MinerApi';
-import { lolminerMonitor, nbminerMonitor, trexminerMonitor } from './monitors';
+import { lolminerMonitor, nbminerMonitor, trexminerMonitor, xmrigMonitor } from './monitors';
 
 const UPDATE_INTERVAL = 1000 * 5;
 const monitor$ = interval(UPDATE_INTERVAL);
 
 export function enableMonitors() {
-  const monitors = [nbminerMonitor, lolminerMonitor, trexminerMonitor];
+  const monitors = [nbminerMonitor, lolminerMonitor, trexminerMonitor, xmrigMonitor];
   const monitorNames = monitors.map((m) => m.name);
 
   monitor$
@@ -21,11 +21,19 @@ export function enableMonitors() {
       const monitor = monitors.find((m) => m.name === status.miner);
 
       if (monitor) {
-        minerApi.stats(API_PORT, monitor.statsUrl).then((result) => {
-          if (result !== '') {
-            monitor.update(result);
-          }
-        });
+        if (typeof monitor.statsUrl === 'string') {
+          minerApi.stats(API_PORT, monitor.statsUrl).then((result) => {
+            if (result !== '') {
+              monitor.update(result);
+            }
+          });
+        } else {
+          const results = await Promise.allSettled(monitor.statsUrl.map(async (url) => minerApi.stats(API_PORT, url)));
+          // eslint-disable-next-line @typescript-eslint/no-shadow
+          const stats = results.filter(({ status }) => status === 'fulfilled').map((p) => (p as PromiseFulfilledResult<string>).value);
+
+          monitor.update(stats);
+        }
       }
     });
 

--- a/src/renderer/services/StatisticsAggregator.ts
+++ b/src/renderer/services/StatisticsAggregator.ts
@@ -1,14 +1,30 @@
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, filter, map, merge, withLatestFrom } from 'rxjs';
 import { minerStarted$ } from './MinerService';
-import { GpuStatistic, MinerStatistic } from '../../models';
+import { CpuStatistic, GpuStatistic, MinerStatistic, minerState$ } from '../../models';
 
+export const cpuStatistics$ = new BehaviorSubject<CpuStatistic>({});
 export const gpuStatistics$ = new BehaviorSubject<GpuStatistic[]>([]);
 export const minerStatistics$ = new BehaviorSubject<MinerStatistic>({});
 
+export const currentHashrate$ = merge(minerStatistics$, cpuStatistics$).pipe(
+  withLatestFrom(minerState$),
+  filter(([,state]) => state.state === 'active'),
+  map(([stat, state]) => ({
+    scale: state.algorithm?.kind === 'GPU' ? 'M' : 'K' as 'M' | 'K',
+    hashrate: stat.hashrate,
+  })),
+);
+
 export function clearStatistics() {
+  cpuStatistics$.next({});
   gpuStatistics$.next([]);
   minerStatistics$.next({});
 }
+
+export function addCpuStat(stat: CpuStatistic) {
+  cpuStatistics$.next(stat);
+}
+
 export function addGpuStats(stats: GpuStatistic[]) {
   gpuStatistics$.next(stats);
 }

--- a/src/renderer/services/monitors/LolminerMonitor.ts
+++ b/src/renderer/services/monitors/LolminerMonitor.ts
@@ -86,6 +86,6 @@ function updateStats(stats: MinerAppStatistics) {
 
 export const monitor: MinerMonitor = {
   name: 'lolminer',
-  statsUrl: '',
-  update: (stats) => updateStats(JSON.parse(stats as string)),
+  statsUrls: [''],
+  update: (stats) => updateStats(JSON.parse(stats[0])),
 };

--- a/src/renderer/services/monitors/LolminerMonitor.ts
+++ b/src/renderer/services/monitors/LolminerMonitor.ts
@@ -87,5 +87,5 @@ function updateStats(stats: MinerAppStatistics) {
 export const monitor: MinerMonitor = {
   name: 'lolminer',
   statsUrl: '',
-  update: (stats) => updateStats(JSON.parse(stats)),
+  update: (stats) => updateStats(JSON.parse(stats as string)),
 };

--- a/src/renderer/services/monitors/MinerMonitor.ts
+++ b/src/renderer/services/monitors/MinerMonitor.ts
@@ -2,6 +2,6 @@ import { MinerName } from '../../../models';
 
 export type MinerMonitor = {
   name: MinerName;
-  statsUrl: string;
-  update: (stats: string) => void;
+  statsUrl: string | string[];
+  update: (stats: string | string[]) => void;
 };

--- a/src/renderer/services/monitors/MinerMonitor.ts
+++ b/src/renderer/services/monitors/MinerMonitor.ts
@@ -2,6 +2,6 @@ import { MinerName } from '../../../models';
 
 export type MinerMonitor = {
   name: MinerName;
-  statsUrl: string | string[];
-  update: (stats: string | string[]) => void;
+  statsUrls: string[];
+  update: (stats: string[]) => void;
 };

--- a/src/renderer/services/monitors/NbminerMonitor.ts
+++ b/src/renderer/services/monitors/NbminerMonitor.ts
@@ -91,5 +91,5 @@ function updateStats(stats: MinerAppStatistics) {
 export const monitor: MinerMonitor = {
   name: 'nbminer',
   statsUrl: 'api/v1/status',
-  update: (stats) => updateStats(JSON.parse(stats)),
+  update: (stats) => updateStats(JSON.parse(stats as string)),
 };

--- a/src/renderer/services/monitors/NbminerMonitor.ts
+++ b/src/renderer/services/monitors/NbminerMonitor.ts
@@ -90,6 +90,6 @@ function updateStats(stats: MinerAppStatistics) {
 
 export const monitor: MinerMonitor = {
   name: 'nbminer',
-  statsUrl: 'api/v1/status',
-  update: (stats) => updateStats(JSON.parse(stats as string)),
+  statsUrls: ['api/v1/status'],
+  update: (stats) => updateStats(JSON.parse(stats[0])),
 };

--- a/src/renderer/services/monitors/TrexMinerMonitor.ts
+++ b/src/renderer/services/monitors/TrexMinerMonitor.ts
@@ -127,6 +127,6 @@ function updateStats(stats: MinerAppStatistics) {
 
 export const monitor: MinerMonitor = {
   name: 'trexminer',
-  statsUrl: 'summary',
-  update: (stats) => updateStats(JSON.parse(stats as string)),
+  statsUrls: ['summary'],
+  update: (stats) => updateStats(JSON.parse(stats[0])),
 };

--- a/src/renderer/services/monitors/TrexMinerMonitor.ts
+++ b/src/renderer/services/monitors/TrexMinerMonitor.ts
@@ -128,5 +128,5 @@ function updateStats(stats: MinerAppStatistics) {
 export const monitor: MinerMonitor = {
   name: 'trexminer',
   statsUrl: 'summary',
-  update: (stats) => updateStats(JSON.parse(stats)),
+  update: (stats) => updateStats(JSON.parse(stats as string)),
 };

--- a/src/renderer/services/monitors/XmrigMonitor.ts
+++ b/src/renderer/services/monitors/XmrigMonitor.ts
@@ -1,4 +1,4 @@
-import { addCpuStat, addGpuStats, addMinerStat } from '../StatisticsAggregator';
+import { addCpuStat } from '../StatisticsAggregator';
 import { MinerMonitor } from './MinerMonitor';
 
 type SummaryStatistics = {
@@ -76,8 +76,29 @@ type SummaryStatistics = {
   hugepages: number[];
 };
 
+type BackendStatistics = {
+  type: string;
+  enabled: true;
+  algo: string;
+  profile: string;
+  priority: number;
+  msr: boolean;
+  asm: string;
+  homepages: number[];
+  memory: number;
+  hashrate: number;
+  threads: {
+    intensity: number;
+    affinity: number;
+    av: number;
+    hashrate: number[];
+  }[];
+};
+
 function updateStats(stats: string[]) {
+  const backends = JSON.parse(stats[0]);
   const summary = JSON.parse(stats[1]) as SummaryStatistics;
+  const cpu = backends[0] as BackendStatistics;
 
   addCpuStat({
     hashrate: summary.hashrate.total[0],
@@ -88,6 +109,11 @@ function updateStats(stats: string[]) {
     algorithm: summary.algo,
     difficulty: summary.connection.diff,
     uptime: summary.uptime,
+    timings: cpu.threads?.map((x) => ({
+      tenSeconds: x.hashrate[0],
+      sixtySeconds: x.hashrate[1],
+      fifteenMinutes: x.hashrate[2],
+    })) ?? [],
   });
 }
 

--- a/src/renderer/services/monitors/XmrigMonitor.ts
+++ b/src/renderer/services/monitors/XmrigMonitor.ts
@@ -1,0 +1,98 @@
+import { addCpuStat, addGpuStats, addMinerStat } from '../StatisticsAggregator';
+import { MinerMonitor } from './MinerMonitor';
+
+type SummaryStatistics = {
+  id: string;
+  worker_id: string;
+  uptime: number;
+  restricted: boolean;
+  resources: {
+    memory: {
+      free: number;
+      total: number;
+      resident_set_memory: number;
+    },
+    load_average: number[];
+    hardware_concurrency: number;
+  };
+  features: string[];
+  results: {
+    diff_current: number;
+    shares_good: number;
+    shares_total: number;
+    avg_time: number;
+    avg_time_ms: number;
+    hashes_total: number;
+    best: number[];
+  };
+  algo: string;
+  connection: {
+    pool: string;
+    ip: string;
+    uptime: number;
+    uptime_ms: number;
+    ping: number;
+    failures: number;
+    tls: number | null;
+    algo: string;
+    diff: number;
+    accepted: number;
+    rejected: number;
+    avg_time: number;
+    avg_time_ms: number;
+    hashes_total: number;
+  };
+  version: string;
+  kind: string;
+  ua: string;
+  cpu: {
+    brand: string;
+    family: number;
+    model: number;
+    stepping: number;
+    proc_info: number;
+    aes: boolean;
+    avx2: boolean;
+    x64: boolean;
+    l2: number;
+    l3: number;
+    cores: number;
+    threads: number;
+    packages: number;
+    nodes: number;
+    backend: string;
+    msr: string;
+    assembly: string;
+    arch: string;
+    flags: string[];
+  };
+  donate_level: number;
+  paused: boolean;
+  algorithms: string[];
+  hashrate: {
+    total: number[];
+    highest: number;
+  };
+  hugepages: number[];
+};
+
+function updateStats(stats: string[]) {
+  const summary = JSON.parse(stats[1]) as SummaryStatistics;
+
+  addCpuStat({
+    hashrate: summary.hashrate.total[0],
+    accepted: summary.connection.accepted,
+    rejected: summary.connection.rejected,
+    cores: summary.cpu.cores,
+    threads: summary.cpu.threads,
+    algorithm: summary.algo,
+    difficulty: summary.connection.diff,
+    uptime: summary.uptime,
+  });
+}
+
+export const monitor: MinerMonitor = {
+  name: 'xmrig',
+  statsUrl: ['2/backends', '2/summary'],
+  update: (stats) => updateStats(stats as string[]),
+};

--- a/src/renderer/services/monitors/XmrigMonitor.ts
+++ b/src/renderer/services/monitors/XmrigMonitor.ts
@@ -119,6 +119,6 @@ function updateStats(stats: string[]) {
 
 export const monitor: MinerMonitor = {
   name: 'xmrig',
-  statsUrl: ['2/backends', '2/summary'],
-  update: (stats) => updateStats(stats as string[]),
+  statsUrls: ['2/backends', '2/summary'],
+  update: (stats) => updateStats(stats),
 };

--- a/src/renderer/services/monitors/index.ts
+++ b/src/renderer/services/monitors/index.ts
@@ -1,4 +1,5 @@
 export { monitor as lolminerMonitor } from './LolminerMonitor';
 export { monitor as nbminerMonitor } from './NbminerMonitor';
 export { monitor as trexminerMonitor } from './TrexMinerMonitor';
+export { monitor as xmrigMonitor } from './XmrigMonitor';
 export { MinerMonitor } from './MinerMonitor';


### PR DESCRIPTION
* Added `xmrig` support using `randomx` algorithm.
* Created new dashboard controls to display CPU mining statistics since they're very different from GPU stats.
* `MinerMonitor` now operates on a collection of urls for statistics (`xmrig` requires two different endpoint calls).
* `minerState$` now tracks the algorithm kind (CPU or GPU) being mined.
* `Formatter` can now selectively format hashrates in three modes: MH/s, KH/s, and raw (no suffix).
* Added new observable for tracking hashrate in a consistent way throughout the application.