### PR TITLE
Widen display area

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -100,9 +100,9 @@ function AppContent() {
         </Drawer>
         <Box
           sx={{
-            marginBottom: '3.5rem',
+            marginBottom: '4.5rem',
             flex: 1,
-            '& .MuiContainer-root': { ml: 0 },
+            '& .MuiContainer-root': { ml: 0, maxWidth: '99%' },
           }}
         >
           <Routes>{safeReverse(links).map(NavScreen)}</Routes>


### PR DESCRIPTION
By default, MUI is capping the main display area to 1200px.  Added an override to change this to 99%.  Also updated the margin bottom to keep the main display from clipping the bottom toolbar.