### PR TITLE
Removed use of Paper component in Wallets screen

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef, useMemo } from 'react';
+import React, { useEffect, useState, useRef, useMemo } from 'react';
 import { HashRouter as Router, Routes, Route, Link } from 'react-router-dom';
 import { from } from 'rxjs';
 import { map, mergeWith } from 'rxjs/operators';
@@ -76,7 +76,6 @@ function AppContent() {
   return (
     <Router>
       <Box sx={{ display: 'flex' }}>
-        <CssBaseline />
         <Drawer
           style={{ width: drawerWidth, display: 'flex' }}
           sx={{
@@ -161,6 +160,7 @@ export function App() {
   return (
     <ThemeProvider theme={mdTheme}>
       <SnackbarProvider maxSnack={5} ref={snackRef} anchorOrigin={{ vertical: 'top', horizontal: 'right' }} action={dismissButton}>
+        <CssBaseline />
         <AppContent />
       </SnackbarProvider>
     </ThemeProvider>

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef, useMemo } from 'react';
+import { useEffect, useState, useRef, useMemo } from 'react';
 import { HashRouter as Router, Routes, Route, Link } from 'react-router-dom';
 import { from } from 'rxjs';
 import { map, mergeWith } from 'rxjs/operators';

--- a/src/renderer/screens/WalletsScreen.tsx
+++ b/src/renderer/screens/WalletsScreen.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { v4 as uuid } from 'uuid';
 
-import { Button, Container, TableContainer, TableCell, TableHead, TableRow, TableBody, Box, Paper, Table } from '@mui/material';
+import { Button, Container, TableContainer, TableCell, TableHead, TableRow, TableBody, Box, Table } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import { useSnackbar } from 'notistack';
 
@@ -85,7 +85,7 @@ export function WalletsScreen() {
         }}
       >
         <EditWalletDialog key="edit-new-wallet" open={isEditingNew} onSave={handleOnAddWalletSave} onCancel={handleOnAddWalletCancel} wallet={newWallet} isNew existingWallets={wallets} coins={[]} />
-        <TableContainer component={Paper}>
+        <TableContainer>
           <Table aria-label="Wallets">
             <TableHead>
               <TableRow>


### PR DESCRIPTION
The `<TableContainer>` in the wallets screen had its `component` attribute set to `Paper`.  No other screen uses this styling.  Removed for consistency.

Also, in the `App.tsx`, moved the reference of `<CssBaseline />` to the main `<App />` render section to keep things cleaner.